### PR TITLE
Неправильное имя внутреннего пакета com.e1c.v8codestyle.bsl.internal

### DIFF
--- a/bundles/com.e1c.v8codestyle.bsl/META-INF/MANIFEST.MF
+++ b/bundles/com.e1c.v8codestyle.bsl/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: com.e1c.v8codestyle.bsl;singleton:=true
 Bundle-Version: 0.1.0.qualifier
-Bundle-Activator: com.e1c.v8codestyle.bsl.internal.BslPlugin
+Bundle-Activator: com.e1c.v8codestyle.internal.bsl.BslPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.0.0,4.0.0)",

--- a/bundles/com.e1c.v8codestyle.bsl/plugin.xml
+++ b/bundles/com.e1c.v8codestyle.bsl/plugin.xml
@@ -24,7 +24,7 @@
       </category>
       <check
             category="com.e1c.v8codestyle.bsl"
-            class="com.e1c.v8codestyle.bsl.internal.ExecutableExtensionFactory:com.e1c.v8codestyle.bsl.check.StructureCtorTooManyKeysCheck">
+            class="com.e1c.v8codestyle.internal.bsl.ExecutableExtensionFactory:com.e1c.v8codestyle.bsl.check.StructureCtorTooManyKeysCheck">
       </check>
    </extension>
 

--- a/bundles/com.e1c.v8codestyle.bsl/src/com/e1c/v8codestyle/internal/bsl/BslPlugin.java
+++ b/bundles/com.e1c.v8codestyle.bsl/src/com/e1c/v8codestyle/internal/bsl/BslPlugin.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     1C-Soft LLC - initial API and implementation
  *******************************************************************************/
-package com.e1c.v8codestyle.bsl.internal;
+package com.e1c.v8codestyle.internal.bsl;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Plugin;

--- a/bundles/com.e1c.v8codestyle.bsl/src/com/e1c/v8codestyle/internal/bsl/ExecutableExtensionFactory.java
+++ b/bundles/com.e1c.v8codestyle.bsl/src/com/e1c/v8codestyle/internal/bsl/ExecutableExtensionFactory.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     1C-Soft LLC - initial API and implementation
  *******************************************************************************/
-package com.e1c.v8codestyle.bsl.internal;
+package com.e1c.v8codestyle.internal.bsl;
 
 import org.osgi.framework.Bundle;
 

--- a/bundles/com.e1c.v8codestyle.bsl/src/com/e1c/v8codestyle/internal/bsl/ExternalDependenciesModule.java
+++ b/bundles/com.e1c.v8codestyle.bsl/src/com/e1c/v8codestyle/internal/bsl/ExternalDependenciesModule.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     1C-Soft LLC - initial API and implementation
  *******************************************************************************/
-package com.e1c.v8codestyle.bsl.internal;
+package com.e1c.v8codestyle.internal.bsl;
 
 import org.eclipse.core.runtime.Plugin;
 


### PR DESCRIPTION
Для внутреннего пакета слово internal должно идти сразу после общего названия бандла.