### PR TITLE
Для проверки structure-consructor-too-many-keys понижена критичность до Minor

### DIFF
--- a/bundles/com.e1c.v8codestyle.bsl/src/com/e1c/v8codestyle/bsl/check/StructureCtorTooManyKeysCheck.java
+++ b/bundles/com.e1c.v8codestyle.bsl/src/com/e1c/v8codestyle/bsl/check/StructureCtorTooManyKeysCheck.java
@@ -57,7 +57,7 @@ public class StructureCtorTooManyKeysCheck
         builder.title(Messages.StructureCtorTooManyKeysCheck_title)
             .description(Messages.StructureCtorTooManyKeysCheck_description)
             .complexity(CheckComplexity.NORMAL)
-            .severity(IssueSeverity.MAJOR)
+            .severity(IssueSeverity.MINOR)
             .issueType(IssueType.CODE_STYLE)
             .module()
             .checkedObjectType(OPERATOR_STYLE_CREATOR)


### PR DESCRIPTION
Проверка structure-consructor-too-many-keys подсвечивает объекты красным, хотя по сути является минорной проверкой.