### PR TITLE
Исправление ложного срабатывания проверки

### DIFF
--- a/bundles/com.e1c.v8codestyle.bsl/plugin.xml
+++ b/bundles/com.e1c.v8codestyle.bsl/plugin.xml
@@ -237,7 +237,7 @@
       </check>
       <check
             category="com.e1c.v8codestyle.bsl"
-            class="com.e1c.v8codestyle.bsl.check.LockOutOfTryCheck">
+            class="com.e1c.v8codestyle.internal.bsl.ExecutableExtensionFactory:com.e1c.v8codestyle.bsl.check.LockOutOfTryCheck">
       </check>
   
    </extension>

--- a/bundles/com.e1c.v8codestyle.bsl/src/com/e1c/v8codestyle/bsl/check/Messages.java
+++ b/bundles/com.e1c.v8codestyle.bsl/src/com/e1c/v8codestyle/bsl/check/Messages.java
@@ -211,8 +211,6 @@ final class Messages
     public static String ModuleUndefinedFunction_msg;
     public static String ModuleUndefinedMethod_msg;
 
-    public static String LockOutOfTry_BeginTransaction_method_must_by_outside_try_block;
-
     public static String LockOutOfTry_Checks_for_init_of_the_data_lock;
 
     public static String LockOutOfTry_Lock_out_of_try;


### PR DESCRIPTION
## Что сделано

<!-- Опишите изменения функциональности, Реализованные проверки кода, метаданных -->

- Исправление ложного срабатывания блокировки вне транзакции, теперь учитываются события вызываемые в неявных транзакциях

<!-- Добавьте скриншоты если необходимо. При добавлении/изменении UI форм - скриншоты обязательны!  -->

## Чек-лист

<!-- 
Перед отправкой вашего PR на аудит пройдите по чек-листу, выполните задачи, отметьте каждый пункт (если применимо).
Если что-то не понятно - лучше уточните в чате.
-->

Общее:
- [x] ветка PR обновлена из `master` и нет конфликтов
- [x] Тесты-кейсы, JUnit тесты правильного и неправильного состояния
- [x] Измененные Вами исходники отформатированы в соответствии [с конвенцией](https://github.com/1C-Company/v8-code-style/blob/master/docs/contributing/code_style.md)
- [ ] Авто-аудит (SonarQube и CheckStyle) пройден, покрытие кода хорошее, ошибок нет, плохой код устранен
- [ ] Добавлена запись в [ИСТОРИЮ ИЗМЕНЕНИЯ](https://github.com/1C-Company/v8-code-style/blob/master/CHANGELOG.md), включаемая в пользовательскую документацию плагина

Если применимо:
- [ ] Пользовательская документация на доп.инструменты написана (на русском)
- [ ] Описание проверок - на двух языках

## Закрываемые задачи

<!-- 
Укажите номер закрываемой задачи (обязательно!)
Например: Closes #123
-->

Closes #999 

<!-- 
С реквестом можно работать долго в статусе Draft (черновик).
По окончании работ, выполнению чек-листа - добавьте комментарий для начала аудита:
@1C-Company @marmyshev прошу сделать аудит
-->
