### PR TITLE
Массовые NPE при расширенной проверки erp из проверки RegisterResourcePrecisionCheck

### DIFF
--- a/bundles/com.e1c.v8codestyle.md/src/com/e1c/v8codestyle/md/check/RegisterResourcePrecisionCheck.java
+++ b/bundles/com.e1c.v8codestyle.md/src/com/e1c/v8codestyle/md/check/RegisterResourcePrecisionCheck.java
@@ -20,9 +20,13 @@ import static com._1c.g5.v8.dt.metadata.mdclass.MdClassPackage.Literals.ACCUMULA
 import java.text.MessageFormat;
 
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.emf.ecore.EObject;
 
 import com._1c.g5.v8.dt.mcore.TypeDescription;
+import com._1c.g5.v8.dt.mcore.util.McoreUtil;
+import com._1c.g5.v8.dt.metadata.mdclass.DefinedType;
 import com._1c.g5.v8.dt.metadata.mdclass.RegisterResource;
+import com._1c.g5.v8.dt.platform.IEObjectTypeNames;
 import com.e1c.g5.v8.dt.check.CheckComplexity;
 import com.e1c.g5.v8.dt.check.ICheckParameters;
 import com.e1c.g5.v8.dt.check.components.BasicCheck;
@@ -84,8 +88,26 @@ public final class RegisterResourcePrecisionCheck
             return;
         }
 
-        TypeDescription td = (TypeDescription)object;
-        if (!(td.eContainer() instanceof RegisterResource))
+        TypeDescription initialTypeDescription = (TypeDescription)object;
+        if (!(initialTypeDescription.eContainer() instanceof RegisterResource))
+        {
+            return;
+        }
+        TypeDescription td = initialTypeDescription;
+        if (td.getTypes().size() == 1
+            && IEObjectTypeNames.DEFINED_TYPE.equals(McoreUtil.getTypeCategory(td.getTypes().get(0))))
+        {
+            EObject definedType = td.getTypes().get(0).eContainer();
+            while (definedType != null && !(definedType instanceof DefinedType))
+            {
+                definedType = definedType.eContainer();
+            }
+            if (definedType instanceof DefinedType)
+            {
+                td = ((DefinedType)definedType).getType();
+            }
+        }
+        if (td.getNumberQualifiers() == null)
         {
             return;
         }
@@ -95,10 +117,10 @@ public final class RegisterResourcePrecisionCheck
 
         if (precision > maxPrecision)
         {
-            RegisterResource resource = (RegisterResource)(td.eContainer());
+            RegisterResource resource = (RegisterResource)(initialTypeDescription.eContainer());
             resultAceptor.addIssue(
                 MessageFormat.format(Messages.RegisterResourcePrecisionCheck_message, resource.getName(), maxPrecision),
-                td);
+                initialTypeDescription);
         }
     }
 }

--- a/tests/com.e1c.v8codestyle.md.itests/src/com/e1c/v8codestyle/md/check/itests/RegisterResourcePrecisionTest.java
+++ b/tests/com.e1c.v8codestyle.md.itests/src/com/e1c/v8codestyle/md/check/itests/RegisterResourcePrecisionTest.java
@@ -71,4 +71,22 @@ public class RegisterResourcePrecisionTest
         Marker marker = getFirstNestedMarker(CHECK_ID, object.bmGetId(), dtProject);
         assertNotNull(marker);
     }
+
+    /**
+     * Test that accounting register resource precision longer than maximal length in user defined type
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    public void testAccountingRegisterResourceWithDefinedTypePrecision() throws Exception
+    {
+        IDtProject dtProject = openProjectAndWaitForValidationFinish(PROJECT_NAME);
+        assertNotNull(dtProject);
+
+        IBmObject object = getTopObjectByFqn("AccountingRegister.AccountingRegisterWithDefinedTypeTest", dtProject);
+        assertNotNull(object);
+
+        Marker marker = getFirstNestedMarker(CHECK_ID, object.bmGetId(), dtProject);
+        assertNotNull(marker);
+    }
 }

--- a/tests/com.e1c.v8codestyle.md.itests/workspace/RegisterResourcePrecision/src/AccountingRegisters/AccountingRegisterWithDefinedTypeTest/AccountingRegisterWithDefinedTypeTest.mdo
+++ b/tests/com.e1c.v8codestyle.md.itests/workspace/RegisterResourcePrecision/src/AccountingRegisters/AccountingRegisterWithDefinedTypeTest/AccountingRegisterWithDefinedTypeTest.mdo
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mdclass:AccountingRegister xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:core="http://g5.1c.ru/v8/dt/mcore" xmlns:mdclass="http://g5.1c.ru/v8/dt/metadata/mdclass" uuid="72833b52-e4dd-4806-9c54-de51460a86e6">
+  <producedTypes>
+    <selectionType typeId="49c35f20-b405-4548-8b9a-df9698c4a7b5" valueTypeId="696338bd-0682-4981-adf5-4742ec1f55c0"/>
+    <listType typeId="8be989ad-6852-4b15-bf77-0e9563bb0dba" valueTypeId="cc3a32c6-5851-40a4-ab99-5a3122593dfc"/>
+    <managerType typeId="3fe5c4a9-efd4-4877-b8a3-ff2917cf5e8d" valueTypeId="6efa16bb-1738-4369-8507-dd53325bcd9c"/>
+    <recordSetType typeId="a2cecc9c-2048-4af1-a377-39e90af67683" valueTypeId="6d19b0c1-37a8-4e84-be01-039dae5e5a85"/>
+    <recordKeyType typeId="5fe3eeb0-d4b0-4992-9fd0-2d73f0340f7c" valueTypeId="037cca83-dbe0-42ac-ae43-69550853932b"/>
+    <recordType typeId="c623a4a8-cc09-4e34-9326-55c971d278e2" valueTypeId="7ed682cd-61bd-496e-bb63-753b843963db"/>
+    <extDimensionsType typeId="e3951c46-457e-42ea-8c98-c1af63c43f5d" valueTypeId="6b666af5-33fc-48ca-a1e3-2ccd2b139757"/>
+  </producedTypes>
+  <name>AccountingRegisterWithDefinedTypeTest</name>
+  <synonym>
+    <key>en</key>
+    <value>Accounting register with defined type test</value>
+  </synonym>
+  <useStandardCommands>true</useStandardCommands>
+  <dataLockControlMode>Managed</dataLockControlMode>
+  <enableTotalsSplitting>true</enableTotalsSplitting>
+  <resources uuid="c3818647-2758-4358-8aec-1fd5cfa366df">
+    <name>CorrectResourceWithDefinedType</name>
+    <synonym>
+      <key>en</key>
+      <value>Correct resource with defined type</value>
+    </synonym>
+    <type>
+      <types>DefinedType.CorrectType</types>
+    </type>
+    <minValue xsi:type="core:UndefinedValue"/>
+    <maxValue xsi:type="core:UndefinedValue"/>
+    <fullTextSearch>Use</fullTextSearch>
+    <balance>true</balance>
+  </resources>
+  <resources uuid="fcea05be-5dbb-4650-bbe7-3554978bd06f">
+    <name>WrongResourceWithDefinedType</name>
+    <synonym>
+      <key>en</key>
+      <value>Wrong resource with defined type</value>
+    </synonym>
+    <type>
+      <types>DefinedType.WrongType</types>
+    </type>
+    <minValue xsi:type="core:UndefinedValue"/>
+    <maxValue xsi:type="core:UndefinedValue"/>
+    <fullTextSearch>Use</fullTextSearch>
+    <balance>true</balance>
+  </resources>
+</mdclass:AccountingRegister>

--- a/tests/com.e1c.v8codestyle.md.itests/workspace/RegisterResourcePrecision/src/Configuration/Configuration.mdo
+++ b/tests/com.e1c.v8codestyle.md.itests/workspace/RegisterResourcePrecision/src/Configuration/Configuration.mdo
@@ -38,7 +38,10 @@
     </synonym>
     <languageCode>en</languageCode>
   </languages>
+  <definedTypes>DefinedType.CorrectType</definedTypes>
+  <definedTypes>DefinedType.WrongType</definedTypes>
   <documents>Document.DocumentTest</documents>
   <accumulationRegisters>AccumulationRegister.AccumulationRegisterTest</accumulationRegisters>
   <accountingRegisters>AccountingRegister.AccountingRegisterTest</accountingRegisters>
+  <accountingRegisters>AccountingRegister.AccountingRegisterWithDefinedTypeTest</accountingRegisters>
 </mdclass:Configuration>

--- a/tests/com.e1c.v8codestyle.md.itests/workspace/RegisterResourcePrecision/src/DefinedTypes/CorrectType/CorrectType.mdo
+++ b/tests/com.e1c.v8codestyle.md.itests/workspace/RegisterResourcePrecision/src/DefinedTypes/CorrectType/CorrectType.mdo
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mdclass:DefinedType xmlns:mdclass="http://g5.1c.ru/v8/dt/metadata/mdclass" uuid="395e33ce-c83c-4202-85cf-d58f72fc6d20">
+  <producedTypes>
+    <containerType typeId="d9a914f3-0edb-40fb-baef-a7672a38bdde" valueTypeId="ceb2bdf4-8f54-420e-92a5-8afdcfe09d58"/>
+  </producedTypes>
+  <name>CorrectType</name>
+  <synonym>
+    <key>en</key>
+    <value>Correct type</value>
+  </synonym>
+  <type>
+    <types>Number</types>
+    <numberQualifiers>
+      <precision>10</precision>
+    </numberQualifiers>
+  </type>
+</mdclass:DefinedType>

--- a/tests/com.e1c.v8codestyle.md.itests/workspace/RegisterResourcePrecision/src/DefinedTypes/WrongType/WrongType.mdo
+++ b/tests/com.e1c.v8codestyle.md.itests/workspace/RegisterResourcePrecision/src/DefinedTypes/WrongType/WrongType.mdo
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mdclass:DefinedType xmlns:mdclass="http://g5.1c.ru/v8/dt/metadata/mdclass" uuid="6f55d133-da1e-4ae8-9201-48b885b1d539">
+  <producedTypes>
+    <containerType typeId="79cad748-4938-427e-a9be-342fbf989e0e" valueTypeId="b0b0de7f-db40-4e08-83df-fb42c8e00277"/>
+  </producedTypes>
+  <name>WrongType</name>
+  <synonym>
+    <key>en</key>
+    <value>Wrong type</value>
+  </synonym>
+  <type>
+    <types>Number</types>
+    <numberQualifiers>
+      <precision>50</precision>
+    </numberQualifiers>
+  </type>
+</mdclass:DefinedType>


### PR DESCRIPTION
Поправил логику проверки в RegisterResourcePrecisionCheck, теперь там учтено, что тип ресурса регистра бухгалтерии и регистра накопления может быть еще определяемый тип, без этого уточнения вылетали массовые NPE.

Добавил на данный случай отдельный тест - com.e1c.v8codestyle.md.check.itests.RegisterResourcePrecisionTest.testAccountingRegisterResourceWithDefinedTypePrecision()