### PR TITLE
G5V8DT-23514 Ошибка при попытке вызвать контекстную подсказку в bsl редакторе

### DIFF
--- a/bundles/com.e1c.v8codestyle.bsl/src/com/e1c/v8codestyle/bsl/check/ModuleUnusedMethodCheck.java
+++ b/bundles/com.e1c.v8codestyle.bsl/src/com/e1c/v8codestyle/bsl/check/ModuleUnusedMethodCheck.java
@@ -102,7 +102,8 @@ public final class ModuleUnusedMethodCheck
         IModuleExtensionService service = IModuleExtensionServiceProvider.INSTANCE.getModuleExtensionService();
         String excludeNamePattern = parameters.getString(EXCLUDE_METHOD_NAME_PATTERN_PARAMETER_NAME);
 
-        Predicate<? super Method> predicate = method -> !method.isUsed() && !method.isExport() && !method.isEvent()
+        Predicate<? super Method> predicate = method -> method.getName() != null && !method.isUsed()
+            && !method.isExport() && !method.isEvent()
             && service.getSourceMethodNames(method).isEmpty() && !isExcludeName(method.getName(), excludeNamePattern);
 
         // TODO - only full validation first, optimization later


### PR DESCRIPTION
## Что сделано

Исправил возможное npe, если модель в модуле не консистентна 
java.lang.NullPointerException
	at com.e1c.v8codestyle.bsl.check.ModuleUnusedMethodCheck.isExcludeName(ModuleUnusedMethodCheck.java:138)
	at com.e1c.v8codestyle.bsl.check.ModuleUnusedMethodCheck.lambda$0(ModuleUnusedMethodCheck.java:106)
	at java.base/java.util.function.Predicate.lambda$and$0(Predicate.java:69)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:176)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
	at com.e1c.v8codestyle.bsl.check.ModuleUnusedMethodCheck.check(ModuleUnusedMethodCheck.java:120)
	at com.e1c.g5.v8.dt.check.components.BasicCheck.check(BasicCheck.java:76)
	at com.e1c.g5.v8.dt.internal.check.CheckExecutor.runLanguageChecks(CheckExecutor.java:722)
	at com.e1c.g5.v8.dt.internal.check.CheckExecutor.validateLanguage(CheckExecutor.java:212)
	at com.e1c.g5.v8.dt.internal.check.bsl.BslValidationContributor.validate(BslValidationContributor.java:176)
	at com._1c.g5.v8.dt.bsl.validation.IBslValidationContributor$pbryglu.validate(Unknown Source)
	at com._1c.g5.v8.dt.bsl.validation.ExternalValidatorServiceProvider.validate(ExternalValidatorServiceProvider.java:78)

