### PR TITLE
G5V8DT-23853 Зависание EDT при редактировании модуля (проверка Xтекст)

### DIFF
--- a/bundles/com.e1c.v8codestyle.bsl/src/com/e1c/v8codestyle/bsl/check/RedundantExportMethodCheck.java
+++ b/bundles/com.e1c.v8codestyle.bsl/src/com/e1c/v8codestyle/bsl/check/RedundantExportMethodCheck.java
@@ -13,6 +13,7 @@
 package com.e1c.v8codestyle.bsl.check;
 
 import static com._1c.g5.v8.dt.bsl.model.BslPackage.Literals.METHOD;
+import static org.eclipse.xtext.resource.impl.ResourceDescriptionsProvider.PERSISTED_DESCRIPTIONS;
 
 import java.text.MessageFormat;
 import java.util.List;
@@ -245,8 +246,7 @@ public final class RedundantExportMethodCheck
 
         ResourceSet resourceSet = new ResourceSetImpl();
         //special ResourceSet for checking by saved modules
-        resourceSet.getLoadOptions()
-            .put(org.eclipse.xtext.resource.impl.ResourceDescriptionsProvider.PERSISTED_DESCRIPTIONS, Boolean.TRUE);
+        resourceSet.getLoadOptions().put(PERSISTED_DESCRIPTIONS, Boolean.TRUE);
 
         IResourceDescriptions indexData = resourceDescriptionsProvider.getResourceDescriptions(resourceSet);
 

--- a/bundles/com.e1c.v8codestyle.bsl/src/com/e1c/v8codestyle/bsl/check/RedundantExportMethodCheck.java
+++ b/bundles/com.e1c.v8codestyle.bsl/src/com/e1c/v8codestyle/bsl/check/RedundantExportMethodCheck.java
@@ -25,7 +25,8 @@ import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
-import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.findReferences.IReferenceFinder;
@@ -242,10 +243,12 @@ public final class RedundantExportMethodCheck
             }
         };
 
-        Resource resource = object.eResource();
+        ResourceSet resourceSet = new ResourceSetImpl();
+        //special ResourceSet for checking by saved modules
+        resourceSet.getLoadOptions()
+            .put(org.eclipse.xtext.resource.impl.ResourceDescriptionsProvider.PERSISTED_DESCRIPTIONS, Boolean.TRUE);
 
-        IResourceDescriptions indexData =
-            resourceDescriptionsProvider.getResourceDescriptions(resource.getResourceSet());
+        IResourceDescriptions indexData = resourceDescriptionsProvider.getResourceDescriptions(resourceSet);
 
         IReferenceFinder.Acceptor acceptor = new IReferenceFinder.Acceptor()
         {


### PR DESCRIPTION
Изменил логику проверки использования экспортируемого метода, теперь проверка выполняется только по сохраненным ресурсам, другого пути обхода возникающих блокировок из задачи https://github.com/1C-Company/1c-edt-issues/issues/1036 пока найти не удалось.

Ветка требует переноса в текущий релиз, иначе проблема зависания при включенной этой проверки носит по сути массовый характер