### PR TITLE
G5V8DT-23852 При редактировании модуля объекта бизнес-процесса EDT не видит типы реквизитов этого бизнес-процесса

### DIFF
--- a/bundles/com.e1c.v8codestyle.bsl/src/com/e1c/v8codestyle/bsl/strict/check/VariableTypeCheck.java
+++ b/bundles/com.e1c.v8codestyle.bsl/src/com/e1c/v8codestyle/bsl/strict/check/VariableTypeCheck.java
@@ -32,6 +32,8 @@ import com._1c.g5.v8.dt.bsl.model.StaticFeatureAccess;
 import com._1c.g5.v8.dt.bsl.model.Variable;
 import com._1c.g5.v8.dt.core.platform.IBmModelManager;
 import com._1c.g5.v8.dt.core.platform.IResourceLookup;
+import com._1c.g5.v8.dt.mcore.Environmental;
+import com._1c.g5.v8.dt.mcore.util.Environments;
 import com.e1c.g5.dt.core.api.naming.INamingService;
 import com.e1c.g5.v8.dt.check.CheckComplexity;
 import com.e1c.g5.v8.dt.check.ICheckParameters;
@@ -123,6 +125,17 @@ public class VariableTypeCheck
     private void checkVariable(Variable variable, EObject checkObject, ResultAcceptor resultAceptor,
         IBmTransaction bmTransaction, IProgressMonitor monitor)
     {
+        if (variable instanceof Environmental)
+        {
+            //checks only variables with selected validation Environments
+            Environments actualEnvs =
+                bslPreferences.getLoadEnvs(checkObject).intersect(((Environmental)variable).environments());
+            if (actualEnvs.isEmpty())
+            {
+                return;
+            }
+        }
+
         if (checkObject != null && variable != null && isEmptyTypes(checkObject, bmTransaction)
             && !monitor.isCanceled())
         {

--- a/tests/com.e1c.v8codestyle.bsl.itests/resources/strict/variable-value-type.bsl
+++ b/tests/com.e1c.v8codestyle.bsl.itests/resources/strict/variable-value-type.bsl
@@ -19,6 +19,12 @@ Procedure Complaint2(Object, AttributeName) Export
 	
 	TestVar2 = Object[AttributeName]; // Number
 	
+	TestVar3 = Object[AttributeName];
+	
+	#If MobileStandaloneServer Then
+		TestVar4 = Object[AttributeName]; 
+	#EndIf
+	
 EndProcedure
 
 // Returns:

--- a/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/strict/check/itests/CommonModuleStrictTypesTest.java
+++ b/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/strict/check/itests/CommonModuleStrictTypesTest.java
@@ -154,15 +154,15 @@ public class CommonModuleStrictTypesTest
 
         List<Marker> markers = getMarters(checkId, module);
 
-        assertEquals(1, markers.size());
+        assertEquals(2, markers.size());
 
         String uriToProblem = EcoreUtil.getURI(variables.get(0)).toString();
-
         Marker marker = markers.get(0);
-
         assertEquals("4", marker.getExtraInfo().get(IExtraInfoKeys.TEXT_EXTRA_INFO_LINE_KEY));
         assertEquals(uriToProblem, marker.getExtraInfo().get(IExtraInfoKeys.TEXT_EXTRA_INFO_URI_TO_PROBLEM_KEY));
 
+        marker = markers.get(1);
+        assertEquals("22", marker.getExtraInfo().get(IExtraInfoKeys.TEXT_EXTRA_INFO_LINE_KEY));
     }
 
     /**


### PR DESCRIPTION
Поправил правила валидации для проверки "variable-value-type" теперь учитываются только переменные в окружении, которое устаноивл пользователь.