### PR TITLE
G5V8DT-22608 Автосортировщик не сортирует дочерние подсистемы после получения изменений из базы

### DIFF
--- a/bundles/com.e1c.v8codestyle.autosort/src/com/e1c/v8codestyle/internal/autosort/SortService.java
+++ b/bundles/com.e1c.v8codestyle.autosort/src/com/e1c/v8codestyle/internal/autosort/SortService.java
@@ -325,7 +325,7 @@ public class SortService
                 {
                     Object notifier = notification.getNotifier();
                     Object value = notification.getNewValue();
-                    if (notifier instanceof IBmObject && value instanceof MdObject)
+                    if (notifier instanceof IBmObject && (value instanceof MdObject || value == null))
                     {
                         changedItems.computeIfAbsent(((IBmObject)notifier).bmGetFqn(), k -> new HashSet<>())
                             .add(listRef);

--- a/bundles/com.e1c.v8codestyle.autosort/src/com/e1c/v8codestyle/internal/autosort/SortService.java
+++ b/bundles/com.e1c.v8codestyle.autosort/src/com/e1c/v8codestyle/internal/autosort/SortService.java
@@ -320,7 +320,8 @@ public class SortService
         {
             for (Notification notification : notifications)
             {
-                if (notification.getEventType() == Notification.ADD)
+                if (notification.getEventType() == Notification.ADD || notification.getEventType() == Notification.MOVE
+                    || notification.getEventType() == Notification.REMOVE)
                 {
                     Object notifier = notification.getNotifier();
                     Object value = notification.getNewValue();

--- a/tests/com.e1c.v8codestyle.autosort.itests/src/com/e1c/v8codestyle/autosort/itests/ExternalDependenciesModule.java
+++ b/tests/com.e1c.v8codestyle.autosort.itests/src/com/e1c/v8codestyle/autosort/itests/ExternalDependenciesModule.java
@@ -16,6 +16,7 @@ import com._1c.g5.v8.activitytracking.core.ISystemIdleService;
 import com._1c.g5.v8.dt.core.platform.IBmModelManager;
 import com._1c.g5.v8.dt.core.platform.IDerivedDataManagerProvider;
 import com._1c.g5.v8.dt.core.platform.IDtProjectManager;
+import com._1c.g5.v8.dt.core.platform.IV8ProjectManager;
 import com._1c.g5.wiring.AbstractServiceAwareModule;
 import com.e1c.v8codestyle.autosort.ISortService;
 import com.e1c.v8codestyle.internal.autosort.AutoSortPlugin;
@@ -41,6 +42,7 @@ public class ExternalDependenciesModule
         bind(ISortService.class).toService();
         bind(IBmModelManager.class).toService();
         bind(IDtProjectManager.class).toService();
+        bind(IV8ProjectManager.class).toService();
         bind(ISystemIdleService.class).toService();
         bind(IDerivedDataManagerProvider.class).toService();
     }

--- a/tests/com.e1c.v8codestyle.autosort.itests/src/com/e1c/v8codestyle/autosort/itests/SortServiceTest.java
+++ b/tests/com.e1c.v8codestyle.autosort.itests/src/com/e1c/v8codestyle/autosort/itests/SortServiceTest.java
@@ -302,6 +302,7 @@ public class SortServiceTest
                 return null;
             }
         });
+
         waitSortStartedlatch.await();
         // wait until sorting is performed.
         TimeUnit.SECONDS.sleep(5);
@@ -382,6 +383,7 @@ public class SortServiceTest
                 return null;
             }
         });
+
         waitSortStartedlatch.await();
         // wait until sorting is performed.
         TimeUnit.SECONDS.sleep(5);

--- a/tests/com.e1c.v8codestyle.autosort.itests/src/com/e1c/v8codestyle/autosort/itests/SortServiceTest.java
+++ b/tests/com.e1c.v8codestyle.autosort.itests/src/com/e1c/v8codestyle/autosort/itests/SortServiceTest.java
@@ -227,7 +227,7 @@ public class SortServiceTest
                 IBmObject commonModule = transaction.getTopObjectByFqn("CommonModule.ГМодуль");
                 Configuration configuration =
                     transaction.toTransactionObject(((IConfigurationAware)v8Project).getConfiguration());
-                configuration.getCommonModules().remove(commonModule);
+                configuration.getCommonModules().remove((CommonModule)commonModule);
                 transaction.detachTopObject(commonModule);
                 return null;
             }
@@ -459,10 +459,17 @@ public class SortServiceTest
         }
 
         /**
-         * @param notification
+         * Specifies how event must be registered.
+         *
+         * @param notification the notification containing event data, cannot be {@code null}
          */
         protected abstract void registerEvent(Notification notification);
 
+        /**
+         * Checks if listener should count down latch.
+         *
+         * @return {@code true} if should count down latch, {@code false} otherwise
+         */
         protected abstract boolean isShouldNotifyAboutEvent();
     }
 }

--- a/tests/com.e1c.v8codestyle.autosort.itests/src/com/e1c/v8codestyle/autosort/itests/SortServiceTest.java
+++ b/tests/com.e1c.v8codestyle.autosort.itests/src/com/e1c/v8codestyle/autosort/itests/SortServiceTest.java
@@ -21,7 +21,9 @@ import static org.junit.Assert.assertTrue;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -31,6 +33,7 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,11 +46,15 @@ import com._1c.g5.v8.bm.integration.AbstractBmTask;
 import com._1c.g5.v8.bm.integration.IBmModel;
 import com._1c.g5.v8.bm.integration.event.IBmSyncEventListener;
 import com._1c.g5.v8.dt.core.platform.IBmModelManager;
+import com._1c.g5.v8.dt.core.platform.IConfigurationAware;
 import com._1c.g5.v8.dt.core.platform.IDtProject;
 import com._1c.g5.v8.dt.core.platform.IDtProjectManager;
+import com._1c.g5.v8.dt.core.platform.IV8Project;
 import com._1c.g5.v8.dt.core.platform.IV8ProjectManager;
 import com._1c.g5.v8.dt.md.sort.MdSortPreferences;
+import com._1c.g5.v8.dt.metadata.mdclass.CommonModule;
 import com._1c.g5.v8.dt.metadata.mdclass.Configuration;
+import com._1c.g5.v8.dt.metadata.mdclass.MdClassFactory;
 import com._1c.g5.v8.dt.testing.GuiceModules;
 import com._1c.g5.v8.dt.testing.JUnitGuiceRunner;
 import com._1c.g5.v8.dt.testing.TestingWorkspace;
@@ -168,235 +175,235 @@ public class SortServiceTest
         assertEquals("ОбщийМодуль", configuration.getCommonModules().get(5).getName());
     }
 
-//    @Ignore("#1365")
-//    @Test
-//    public void testSortAfterRemoveEvent() throws Exception
-//    {
-//        IProject project = testingWorkspace.setUpProject(PROJECT_NAME, getClass());
-//        assertNotNull(project);
-//        IDtProject dtProject = dtProjectManager.getDtProject(project);
-//        assertNotNull(dtProject);
-//        IV8Project v8Project = v8ProjectManager.getProject(dtProject);
-//        assertNotNull(dtProject);
-//
-//        IEclipsePreferences autoSortPrefs = AutoSortPreferences.getPreferences(project);
-//        autoSortPrefs.putBoolean(AutoSortPreferences.KEY_ALL_TOP, true);
-//        autoSortPrefs.flush();
-//
-//        IEclipsePreferences mdSortPrefs = MdSortPreferences.getPreferences(project);
-//        mdSortPrefs.putBoolean(MdSortPreferences.NATURAL_SORT_ORDER, false);
-//        mdSortPrefs.flush();
-//
-//        CountDownLatch waitSortStartedlatch = new CountDownLatch(1);
-//        bmModelManager.addSyncEventListener(bmModelManager.getBmNamespace(project),
-//            new BmEventListener(project, waitSortStartedlatch)
-//            {
-//                boolean isBmObjectRemoved = false;
-//                boolean isStortStarted = false;
-//
-//                @Override
-//                protected void registerEvent(Notification notification)
-//                {
-//                    if (notification.getEventType() == Notification.REMOVE)
-//                    {
-//                        isBmObjectRemoved = true;
-//                    }
-//                    else if (notification.getEventType() == Notification.MOVE)
-//                    {
-//                        isStortStarted = true;
-//                    }
-//                }
-//
-//                @Override
-//                protected boolean isShouldCountDownLatch()
-//                {
-//                    return isBmObjectRemoved && isStortStarted;
-//                }
-//            });
-//
-//        bmModelManager.getModel(project).execute(new AbstractBmTask<Void>("Detach a top object") //$NON-NLS-1$
-//        {
-//            @Override
-//            public Void execute(IBmTransaction transaction, IProgressMonitor monitor)
-//            {
-//                IBmObject commonModule = transaction.getTopObjectByFqn("CommonModule.ГМодуль");
-//                Configuration configuration =
-//                    transaction.toTransactionObject(((IConfigurationAware)v8Project).getConfiguration());
-//                configuration.getCommonModules().remove((CommonModule)commonModule);
-//                transaction.detachTopObject(commonModule);
-//                return null;
-//            }
-//        });
-//
-//        waitSortStartedlatch.await();
-//        // wait until sorting is completed.
-//        TimeUnit.SECONDS.sleep(5);
-//
-//        IBmObject object = getTopObjectByFqn(CONFIGURATION.getName(), dtProject);
-//        assertTrue(object instanceof Configuration);
-//
-//        Configuration configuration = (Configuration)object;
-//        assertFalse(configuration.getCommonModules().isEmpty());
-//
-//        assertEquals("АМ_Модуль", configuration.getCommonModules().get(0).getName());
-//        assertEquals("АМ2_4Модуль", configuration.getCommonModules().get(1).getName());
-//        assertEquals("АМодуль", configuration.getCommonModules().get(2).getName());
-//        assertEquals("БМодуль", configuration.getCommonModules().get(3).getName());
-//        assertEquals("ОбщийМодуль", configuration.getCommonModules().get(4).getName());
-//    }
-//
-//    @Ignore("#1365")
-//    @Test
-//    public void testSortAfterMoveEvent() throws Exception
-//    {
-//        IProject project = testingWorkspace.setUpProject(PROJECT_NAME, getClass());
-//        assertNotNull(project);
-//        IDtProject dtProject = dtProjectManager.getDtProject(project);
-//        assertNotNull(dtProject);
-//        IV8Project v8Project = v8ProjectManager.getProject(dtProject);
-//        assertNotNull(dtProject);
-//
-//        IEclipsePreferences autoSortPrefs = AutoSortPreferences.getPreferences(project);
-//        autoSortPrefs.putBoolean(AutoSortPreferences.KEY_ALL_TOP, true);
-//        autoSortPrefs.flush();
-//
-//        IEclipsePreferences mdSortPrefs = MdSortPreferences.getPreferences(project);
-//        mdSortPrefs.putBoolean(MdSortPreferences.NATURAL_SORT_ORDER, false);
-//        mdSortPrefs.flush();
-//
-//        CountDownLatch waitSortStartedlatch = new CountDownLatch(1);
-//        bmModelManager.addSyncEventListener(bmModelManager.getBmNamespace(project),
-//            new BmEventListener(project, waitSortStartedlatch)
-//            {
-//                private int moveCount = 0;
-//
-//                @Override
-//                protected void registerEvent(Notification notification)
-//                {
-//                    if (notification.getEventType() == Notification.MOVE)
-//                    {
-//                        moveCount++;
-//                    }
-//                }
-//
-//                @Override
-//                protected boolean isShouldCountDownLatch()
-//                {
-//                    return moveCount == 2;
-//                }
-//            });
-//
-//        bmModelManager.getModel(project).execute(new AbstractBmTask<Void>("Move a top object") //$NON-NLS-1$
-//        {
-//            @Override
-//            public Void execute(IBmTransaction transaction, IProgressMonitor progressMonitor)
-//            {
-//                IBmObject commonModule = transaction.getTopObjectByFqn("CommonModule.БМодуль");
-//                Configuration configuration =
-//                    transaction.toTransactionObject(((IConfigurationAware)v8Project).getConfiguration());
-//                configuration.getCommonModules().move(4, (CommonModule)commonModule);
-//                return null;
-//            }
-//        });
-//
-//        waitSortStartedlatch.await();
-//        // wait until sorting is performed.
-//        TimeUnit.SECONDS.sleep(5);
-//
-//        IBmObject object = getTopObjectByFqn(CONFIGURATION.getName(), dtProject);
-//        assertTrue(object instanceof Configuration);
-//
-//        Configuration configuration = (Configuration)object;
-//        assertFalse(configuration.getCommonModules().isEmpty());
-//
-//        assertEquals("АМ_Модуль", configuration.getCommonModules().get(0).getName());
-//        assertEquals("АМ2_4Модуль", configuration.getCommonModules().get(1).getName());
-//        assertEquals("АМодуль", configuration.getCommonModules().get(2).getName());
-//        assertEquals("БМодуль", configuration.getCommonModules().get(3).getName());
-//        assertEquals("ГМодуль", configuration.getCommonModules().get(4).getName());
-//        assertEquals("ОбщийМодуль", configuration.getCommonModules().get(5).getName());
-//    }
-//
-//    @Ignore("#1365")
-//    @Test
-//    public void testSortAfterAddEvent() throws Exception
-//    {
-//        IProject project = testingWorkspace.setUpProject(PROJECT_NAME, getClass());
-//        assertNotNull(project);
-//        IDtProject dtProject = dtProjectManager.getDtProject(project);
-//        assertNotNull(dtProject);
-//        IV8Project v8Project = v8ProjectManager.getProject(dtProject);
-//        assertNotNull(dtProject);
-//
-//        IEclipsePreferences autoSortPrefs = AutoSortPreferences.getPreferences(project);
-//        autoSortPrefs.putBoolean(AutoSortPreferences.KEY_ALL_TOP, true);
-//        autoSortPrefs.flush();
-//
-//        IEclipsePreferences mdSortPrefs = MdSortPreferences.getPreferences(project);
-//        mdSortPrefs.putBoolean(MdSortPreferences.NATURAL_SORT_ORDER, false);
-//        mdSortPrefs.flush();
-//
-//        CountDownLatch waitSortStartedlatch = new CountDownLatch(1);
-//        bmModelManager.addSyncEventListener(bmModelManager.getBmNamespace(project),
-//            new BmEventListener(project, waitSortStartedlatch)
-//            {
-//                boolean isBmObjectAdded = false;
-//                boolean isStortStarted = false;
-//
-//                @Override
-//                protected void registerEvent(Notification notification)
-//                {
-//                    if (notification.getEventType() == Notification.ADD)
-//                    {
-//                        isBmObjectAdded = true;
-//                    }
-//                    else if (notification.getEventType() == Notification.MOVE)
-//                    {
-//                        isStortStarted = true;
-//                    }
-//                }
-//
-//                @Override
-//                protected boolean isShouldCountDownLatch()
-//                {
-//                    return isBmObjectAdded && isStortStarted;
-//                }
-//            });
-//
-//        bmModelManager.getModel(project).execute(new AbstractBmTask<Void>("Add a top object") //$NON-NLS-1$
-//        {
-//            @Override
-//            public Void execute(IBmTransaction transaction, IProgressMonitor progressMonitor)
-//            {
-//                CommonModule commonModule = MdClassFactory.eINSTANCE.createCommonModule();
-//                commonModule.setName("КМодуль");
-//                commonModule.setUuid(UUID.randomUUID());
-//                transaction.attachTopObject((IBmObject)commonModule, "CommonModule.КМодуль");
-//
-//                Configuration configuration =
-//                    transaction.toTransactionObject(((IConfigurationAware)v8Project).getConfiguration());
-//
-//                configuration.getCommonModules().add(commonModule);
-//                return null;
-//            }
-//        });
-//
-//        waitSortStartedlatch.await();
-//        // wait until sorting is performed.
-//        TimeUnit.SECONDS.sleep(5);
-//
-//        IBmObject object = getTopObjectByFqn(CONFIGURATION.getName(), dtProject);
-//        Configuration configuration = (Configuration)object;
-//        assertFalse(configuration.getCommonModules().isEmpty());
-//
-//        assertEquals("АМ_Модуль", configuration.getCommonModules().get(0).getName());
-//        assertEquals("АМ2_4Модуль", configuration.getCommonModules().get(1).getName());
-//        assertEquals("АМодуль", configuration.getCommonModules().get(2).getName());
-//        assertEquals("БМодуль", configuration.getCommonModules().get(3).getName());
-//        assertEquals("ГМодуль", configuration.getCommonModules().get(4).getName());
-//        assertEquals("КМодуль", configuration.getCommonModules().get(5).getName());
-//        assertEquals("ОбщийМодуль", configuration.getCommonModules().get(6).getName());
-//    }
+    @Ignore("#1365")
+    @Test
+    public void testSortAfterRemoveEvent() throws Exception
+    {
+        IProject project = testingWorkspace.setUpProject(PROJECT_NAME, getClass());
+        assertNotNull(project);
+        IDtProject dtProject = dtProjectManager.getDtProject(project);
+        assertNotNull(dtProject);
+        IV8Project v8Project = v8ProjectManager.getProject(dtProject);
+        assertNotNull(dtProject);
+
+        IEclipsePreferences autoSortPrefs = AutoSortPreferences.getPreferences(project);
+        autoSortPrefs.putBoolean(AutoSortPreferences.KEY_ALL_TOP, true);
+        autoSortPrefs.flush();
+
+        IEclipsePreferences mdSortPrefs = MdSortPreferences.getPreferences(project);
+        mdSortPrefs.putBoolean(MdSortPreferences.NATURAL_SORT_ORDER, false);
+        mdSortPrefs.flush();
+
+        CountDownLatch waitSortStartedlatch = new CountDownLatch(1);
+        bmModelManager.addSyncEventListener(bmModelManager.getBmNamespace(project),
+            new BmEventListener(project, waitSortStartedlatch)
+            {
+                boolean isBmObjectRemoved = false;
+                boolean isStortStarted = false;
+
+                @Override
+                protected void registerEvent(Notification notification)
+                {
+                    if (notification.getEventType() == Notification.REMOVE)
+                    {
+                        isBmObjectRemoved = true;
+                    }
+                    else if (notification.getEventType() == Notification.MOVE)
+                    {
+                        isStortStarted = true;
+                    }
+                }
+
+                @Override
+                protected boolean isShouldCountDownLatch()
+                {
+                    return isBmObjectRemoved && isStortStarted;
+                }
+            });
+
+        bmModelManager.getModel(project).execute(new AbstractBmTask<Void>("Detach a top object") //$NON-NLS-1$
+        {
+            @Override
+            public Void execute(IBmTransaction transaction, IProgressMonitor monitor)
+            {
+                IBmObject commonModule = transaction.getTopObjectByFqn("CommonModule.ГМодуль");
+                Configuration configuration =
+                    transaction.toTransactionObject(((IConfigurationAware)v8Project).getConfiguration());
+                configuration.getCommonModules().remove((CommonModule)commonModule);
+                transaction.detachTopObject(commonModule);
+                return null;
+            }
+        });
+
+        waitSortStartedlatch.await();
+        // wait until sorting is completed.
+        TimeUnit.SECONDS.sleep(5);
+
+        IBmObject object = getTopObjectByFqn(CONFIGURATION.getName(), dtProject);
+        assertTrue(object instanceof Configuration);
+
+        Configuration configuration = (Configuration)object;
+        assertFalse(configuration.getCommonModules().isEmpty());
+
+        assertEquals("АМ_Модуль", configuration.getCommonModules().get(0).getName());
+        assertEquals("АМ2_4Модуль", configuration.getCommonModules().get(1).getName());
+        assertEquals("АМодуль", configuration.getCommonModules().get(2).getName());
+        assertEquals("БМодуль", configuration.getCommonModules().get(3).getName());
+        assertEquals("ОбщийМодуль", configuration.getCommonModules().get(4).getName());
+    }
+
+    @Ignore("#1365")
+    @Test
+    public void testSortAfterMoveEvent() throws Exception
+    {
+        IProject project = testingWorkspace.setUpProject(PROJECT_NAME, getClass());
+        assertNotNull(project);
+        IDtProject dtProject = dtProjectManager.getDtProject(project);
+        assertNotNull(dtProject);
+        IV8Project v8Project = v8ProjectManager.getProject(dtProject);
+        assertNotNull(dtProject);
+
+        IEclipsePreferences autoSortPrefs = AutoSortPreferences.getPreferences(project);
+        autoSortPrefs.putBoolean(AutoSortPreferences.KEY_ALL_TOP, true);
+        autoSortPrefs.flush();
+
+        IEclipsePreferences mdSortPrefs = MdSortPreferences.getPreferences(project);
+        mdSortPrefs.putBoolean(MdSortPreferences.NATURAL_SORT_ORDER, false);
+        mdSortPrefs.flush();
+
+        CountDownLatch waitSortStartedlatch = new CountDownLatch(1);
+        bmModelManager.addSyncEventListener(bmModelManager.getBmNamespace(project),
+            new BmEventListener(project, waitSortStartedlatch)
+            {
+                private int moveCount = 0;
+
+                @Override
+                protected void registerEvent(Notification notification)
+                {
+                    if (notification.getEventType() == Notification.MOVE)
+                    {
+                        moveCount++;
+                    }
+                }
+
+                @Override
+                protected boolean isShouldCountDownLatch()
+                {
+                    return moveCount == 2;
+                }
+            });
+
+        bmModelManager.getModel(project).execute(new AbstractBmTask<Void>("Move a top object") //$NON-NLS-1$
+        {
+            @Override
+            public Void execute(IBmTransaction transaction, IProgressMonitor progressMonitor)
+            {
+                IBmObject commonModule = transaction.getTopObjectByFqn("CommonModule.БМодуль");
+                Configuration configuration =
+                    transaction.toTransactionObject(((IConfigurationAware)v8Project).getConfiguration());
+                configuration.getCommonModules().move(4, (CommonModule)commonModule);
+                return null;
+            }
+        });
+
+        waitSortStartedlatch.await();
+        // wait until sorting is performed.
+        TimeUnit.SECONDS.sleep(5);
+
+        IBmObject object = getTopObjectByFqn(CONFIGURATION.getName(), dtProject);
+        assertTrue(object instanceof Configuration);
+
+        Configuration configuration = (Configuration)object;
+        assertFalse(configuration.getCommonModules().isEmpty());
+
+        assertEquals("АМ_Модуль", configuration.getCommonModules().get(0).getName());
+        assertEquals("АМ2_4Модуль", configuration.getCommonModules().get(1).getName());
+        assertEquals("АМодуль", configuration.getCommonModules().get(2).getName());
+        assertEquals("БМодуль", configuration.getCommonModules().get(3).getName());
+        assertEquals("ГМодуль", configuration.getCommonModules().get(4).getName());
+        assertEquals("ОбщийМодуль", configuration.getCommonModules().get(5).getName());
+    }
+
+    @Ignore("#1365")
+    @Test
+    public void testSortAfterAddEvent() throws Exception
+    {
+        IProject project = testingWorkspace.setUpProject(PROJECT_NAME, getClass());
+        assertNotNull(project);
+        IDtProject dtProject = dtProjectManager.getDtProject(project);
+        assertNotNull(dtProject);
+        IV8Project v8Project = v8ProjectManager.getProject(dtProject);
+        assertNotNull(dtProject);
+
+        IEclipsePreferences autoSortPrefs = AutoSortPreferences.getPreferences(project);
+        autoSortPrefs.putBoolean(AutoSortPreferences.KEY_ALL_TOP, true);
+        autoSortPrefs.flush();
+
+        IEclipsePreferences mdSortPrefs = MdSortPreferences.getPreferences(project);
+        mdSortPrefs.putBoolean(MdSortPreferences.NATURAL_SORT_ORDER, false);
+        mdSortPrefs.flush();
+
+        CountDownLatch waitSortStartedlatch = new CountDownLatch(1);
+        bmModelManager.addSyncEventListener(bmModelManager.getBmNamespace(project),
+            new BmEventListener(project, waitSortStartedlatch)
+            {
+                boolean isBmObjectAdded = false;
+                boolean isStortStarted = false;
+
+                @Override
+                protected void registerEvent(Notification notification)
+                {
+                    if (notification.getEventType() == Notification.ADD)
+                    {
+                        isBmObjectAdded = true;
+                    }
+                    else if (notification.getEventType() == Notification.MOVE)
+                    {
+                        isStortStarted = true;
+                    }
+                }
+
+                @Override
+                protected boolean isShouldCountDownLatch()
+                {
+                    return isBmObjectAdded && isStortStarted;
+                }
+            });
+
+        bmModelManager.getModel(project).execute(new AbstractBmTask<Void>("Add a top object") //$NON-NLS-1$
+        {
+            @Override
+            public Void execute(IBmTransaction transaction, IProgressMonitor progressMonitor)
+            {
+                CommonModule commonModule = MdClassFactory.eINSTANCE.createCommonModule();
+                commonModule.setName("КМодуль");
+                commonModule.setUuid(UUID.randomUUID());
+                transaction.attachTopObject((IBmObject)commonModule, "CommonModule.КМодуль");
+
+                Configuration configuration =
+                    transaction.toTransactionObject(((IConfigurationAware)v8Project).getConfiguration());
+
+                configuration.getCommonModules().add(commonModule);
+                return null;
+            }
+        });
+
+        waitSortStartedlatch.await();
+        // wait until sorting is performed.
+        TimeUnit.SECONDS.sleep(5);
+
+        IBmObject object = getTopObjectByFqn(CONFIGURATION.getName(), dtProject);
+        Configuration configuration = (Configuration)object;
+        assertFalse(configuration.getCommonModules().isEmpty());
+
+        assertEquals("АМ_Модуль", configuration.getCommonModules().get(0).getName());
+        assertEquals("АМ2_4Модуль", configuration.getCommonModules().get(1).getName());
+        assertEquals("АМодуль", configuration.getCommonModules().get(2).getName());
+        assertEquals("БМодуль", configuration.getCommonModules().get(3).getName());
+        assertEquals("ГМодуль", configuration.getCommonModules().get(4).getName());
+        assertEquals("КМодуль", configuration.getCommonModules().get(5).getName());
+        assertEquals("ОбщийМодуль", configuration.getCommonModules().get(6).getName());
+    }
 
     protected IBmObject getTopObjectByFqn(final String fqn, IDtProject dtProject)
     {

--- a/tests/com.e1c.v8codestyle.autosort.itests/src/com/e1c/v8codestyle/autosort/itests/SortServiceTest.java
+++ b/tests/com.e1c.v8codestyle.autosort.itests/src/com/e1c/v8codestyle/autosort/itests/SortServiceTest.java
@@ -213,7 +213,7 @@ public class SortServiceTest
                 }
 
                 @Override
-                protected boolean isShouldNotifyAboutEvent()
+                protected boolean isShouldCountDownLatch()
                 {
                     return isBmObjectRemoved && isStortStarted;
                 }
@@ -284,7 +284,7 @@ public class SortServiceTest
                 }
 
                 @Override
-                protected boolean isShouldNotifyAboutEvent()
+                protected boolean isShouldCountDownLatch()
                 {
                     return moveCount == 2;
                 }
@@ -359,7 +359,7 @@ public class SortServiceTest
                 }
 
                 @Override
-                protected boolean isShouldNotifyAboutEvent()
+                protected boolean isShouldCountDownLatch()
                 {
                     return isBmObjectAdded && isStortStarted;
                 }
@@ -452,7 +452,7 @@ public class SortServiceTest
                     }
                 }
             }
-            if (isShouldNotifyAboutEvent())
+            if (isShouldCountDownLatch())
             {
                 latch.countDown();
             }
@@ -470,6 +470,6 @@ public class SortServiceTest
          *
          * @return {@code true} if should count down latch, {@code false} otherwise
          */
-        protected abstract boolean isShouldNotifyAboutEvent();
+        protected abstract boolean isShouldCountDownLatch();
     }
 }

--- a/tests/com.e1c.v8codestyle.autosort.itests/src/com/e1c/v8codestyle/autosort/itests/SortServiceTest.java
+++ b/tests/com.e1c.v8codestyle.autosort.itests/src/com/e1c/v8codestyle/autosort/itests/SortServiceTest.java
@@ -189,7 +189,7 @@ public class SortServiceTest
                 IBmObject commonModule = transaction.getTopObjectByFqn("CommonModule.ГМодуль");
                 Configuration configuration =
                     transaction.toTransactionObject(((IConfigurationAware)v8Project).getConfiguration());
-                configuration.getCommonModules().remove(commonModule);
+                configuration.getCommonModules().remove((CommonModule)commonModule);
                 transaction.detachTopObject(commonModule);
                 return null;
             }

--- a/tests/com.e1c.v8codestyle.autosort.itests/src/com/e1c/v8codestyle/autosort/itests/SortServiceTest.java
+++ b/tests/com.e1c.v8codestyle.autosort.itests/src/com/e1c/v8codestyle/autosort/itests/SortServiceTest.java
@@ -168,7 +168,7 @@ public class SortServiceTest
         assertEquals("ОбщийМодуль", configuration.getCommonModules().get(5).getName());
     }
 
-//    @Ignore("G5V8DT-22608")
+//    @Ignore("#1365")
 //    @Test
 //    public void testSortAfterRemoveEvent() throws Exception
 //    {
@@ -245,7 +245,7 @@ public class SortServiceTest
 //        assertEquals("ОбщийМодуль", configuration.getCommonModules().get(4).getName());
 //    }
 //
-//    @Ignore("G5V8DT-22608")
+//    @Ignore("#1365")
 //    @Test
 //    public void testSortAfterMoveEvent() throws Exception
 //    {
@@ -317,7 +317,7 @@ public class SortServiceTest
 //        assertEquals("ОбщийМодуль", configuration.getCommonModules().get(5).getName());
 //    }
 //
-//    @Ignore("G5V8DT-22608")
+//    @Ignore("#1365")
 //    @Test
 //    public void testSortAfterAddEvent() throws Exception
 //    {

--- a/tests/com.e1c.v8codestyle.autosort.itests/src/com/e1c/v8codestyle/autosort/itests/SortServiceTest.java
+++ b/tests/com.e1c.v8codestyle.autosort.itests/src/com/e1c/v8codestyle/autosort/itests/SortServiceTest.java
@@ -33,6 +33,7 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -174,6 +175,7 @@ public class SortServiceTest
         assertEquals("ОбщийМодуль", configuration.getCommonModules().get(5).getName());
     }
 
+    @Ignore("G5V8DT-24222")
     @Test
     public void testSortAfterRemoveEvent() throws Exception
     {
@@ -227,7 +229,7 @@ public class SortServiceTest
                 IBmObject commonModule = transaction.getTopObjectByFqn("CommonModule.ГМодуль");
                 Configuration configuration =
                     transaction.toTransactionObject(((IConfigurationAware)v8Project).getConfiguration());
-                configuration.getCommonModules().remove((CommonModule)commonModule);
+                configuration.getCommonModules().remove(commonModule);
                 transaction.detachTopObject(commonModule);
                 return null;
             }
@@ -250,6 +252,7 @@ public class SortServiceTest
         assertEquals("ОбщийМодуль", configuration.getCommonModules().get(4).getName());
     }
 
+    @Ignore("G5V8DT-24222")
     @Test
     public void testSortAfterMoveEvent() throws Exception
     {
@@ -321,6 +324,7 @@ public class SortServiceTest
         assertEquals("ОбщийМодуль", configuration.getCommonModules().get(5).getName());
     }
 
+    @Ignore("G5V8DT-24222")
     @Test
     public void testSortAfterAddEvent() throws Exception
     {

--- a/tests/com.e1c.v8codestyle.autosort.itests/src/com/e1c/v8codestyle/autosort/itests/SortServiceTest.java
+++ b/tests/com.e1c.v8codestyle.autosort.itests/src/com/e1c/v8codestyle/autosort/itests/SortServiceTest.java
@@ -194,7 +194,7 @@ public class SortServiceTest
                 return null;
             }
         });
-        TimeUnit.SECONDS.sleep(10);
+        TimeUnit.SECONDS.sleep(20);
 
         IBmObject object = getTopObjectByFqn(CONFIGURATION.getName(), dtProject);
         assertTrue(object instanceof Configuration);
@@ -240,7 +240,7 @@ public class SortServiceTest
                 return null;
             }
         });
-        TimeUnit.SECONDS.sleep(10);
+        TimeUnit.SECONDS.sleep(20);
 
         IBmObject object = getTopObjectByFqn(CONFIGURATION.getName(), dtProject);
         assertTrue(object instanceof Configuration);
@@ -291,7 +291,7 @@ public class SortServiceTest
                 return null;
             }
         });
-        TimeUnit.SECONDS.sleep(10);
+        TimeUnit.SECONDS.sleep(20);
 
         IBmObject object = getTopObjectByFqn(CONFIGURATION.getName(), dtProject);
         Configuration configuration = (Configuration)object;

--- a/tests/com.e1c.v8codestyle.autosort.itests/src/com/e1c/v8codestyle/autosort/itests/SortServiceTest.java
+++ b/tests/com.e1c.v8codestyle.autosort.itests/src/com/e1c/v8codestyle/autosort/itests/SortServiceTest.java
@@ -175,7 +175,7 @@ public class SortServiceTest
         assertEquals("ОбщийМодуль", configuration.getCommonModules().get(5).getName());
     }
 
-    @Ignore("G5V8DT-24222")
+    @Ignore("G5V8DT-22608")
     @Test
     public void testSortAfterRemoveEvent() throws Exception
     {
@@ -229,7 +229,7 @@ public class SortServiceTest
                 IBmObject commonModule = transaction.getTopObjectByFqn("CommonModule.ГМодуль");
                 Configuration configuration =
                     transaction.toTransactionObject(((IConfigurationAware)v8Project).getConfiguration());
-                configuration.getCommonModules().remove(commonModule);
+                configuration.getCommonModules().remove((CommonModule)commonModule);
                 transaction.detachTopObject(commonModule);
                 return null;
             }
@@ -252,7 +252,7 @@ public class SortServiceTest
         assertEquals("ОбщийМодуль", configuration.getCommonModules().get(4).getName());
     }
 
-    @Ignore("G5V8DT-24222")
+    @Ignore("G5V8DT-22608")
     @Test
     public void testSortAfterMoveEvent() throws Exception
     {
@@ -324,7 +324,7 @@ public class SortServiceTest
         assertEquals("ОбщийМодуль", configuration.getCommonModules().get(5).getName());
     }
 
-    @Ignore("G5V8DT-24222")
+    @Ignore("G5V8DT-22608")
     @Test
     public void testSortAfterAddEvent() throws Exception
     {

--- a/tests/com.e1c.v8codestyle.autosort.itests/src/com/e1c/v8codestyle/autosort/itests/SortServiceTest.java
+++ b/tests/com.e1c.v8codestyle.autosort.itests/src/com/e1c/v8codestyle/autosort/itests/SortServiceTest.java
@@ -21,9 +21,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -33,7 +31,6 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,15 +43,11 @@ import com._1c.g5.v8.bm.integration.AbstractBmTask;
 import com._1c.g5.v8.bm.integration.IBmModel;
 import com._1c.g5.v8.bm.integration.event.IBmSyncEventListener;
 import com._1c.g5.v8.dt.core.platform.IBmModelManager;
-import com._1c.g5.v8.dt.core.platform.IConfigurationAware;
 import com._1c.g5.v8.dt.core.platform.IDtProject;
 import com._1c.g5.v8.dt.core.platform.IDtProjectManager;
-import com._1c.g5.v8.dt.core.platform.IV8Project;
 import com._1c.g5.v8.dt.core.platform.IV8ProjectManager;
 import com._1c.g5.v8.dt.md.sort.MdSortPreferences;
-import com._1c.g5.v8.dt.metadata.mdclass.CommonModule;
 import com._1c.g5.v8.dt.metadata.mdclass.Configuration;
-import com._1c.g5.v8.dt.metadata.mdclass.MdClassFactory;
 import com._1c.g5.v8.dt.testing.GuiceModules;
 import com._1c.g5.v8.dt.testing.JUnitGuiceRunner;
 import com._1c.g5.v8.dt.testing.TestingWorkspace;
@@ -175,235 +168,235 @@ public class SortServiceTest
         assertEquals("ОбщийМодуль", configuration.getCommonModules().get(5).getName());
     }
 
-    @Ignore("G5V8DT-22608")
-    @Test
-    public void testSortAfterRemoveEvent() throws Exception
-    {
-        IProject project = testingWorkspace.setUpProject(PROJECT_NAME, getClass());
-        assertNotNull(project);
-        IDtProject dtProject = dtProjectManager.getDtProject(project);
-        assertNotNull(dtProject);
-        IV8Project v8Project = v8ProjectManager.getProject(dtProject);
-        assertNotNull(dtProject);
-
-        IEclipsePreferences autoSortPrefs = AutoSortPreferences.getPreferences(project);
-        autoSortPrefs.putBoolean(AutoSortPreferences.KEY_ALL_TOP, true);
-        autoSortPrefs.flush();
-
-        IEclipsePreferences mdSortPrefs = MdSortPreferences.getPreferences(project);
-        mdSortPrefs.putBoolean(MdSortPreferences.NATURAL_SORT_ORDER, false);
-        mdSortPrefs.flush();
-
-        CountDownLatch waitSortStartedlatch = new CountDownLatch(1);
-        bmModelManager.addSyncEventListener(bmModelManager.getBmNamespace(project),
-            new BmEventListener(project, waitSortStartedlatch)
-            {
-                boolean isBmObjectRemoved = false;
-                boolean isStortStarted = false;
-
-                @Override
-                protected void registerEvent(Notification notification)
-                {
-                    if (notification.getEventType() == Notification.REMOVE)
-                    {
-                        isBmObjectRemoved = true;
-                    }
-                    else if (notification.getEventType() == Notification.MOVE)
-                    {
-                        isStortStarted = true;
-                    }
-                }
-
-                @Override
-                protected boolean isShouldCountDownLatch()
-                {
-                    return isBmObjectRemoved && isStortStarted;
-                }
-            });
-
-        bmModelManager.getModel(project).execute(new AbstractBmTask<Void>("Detach a top object") //$NON-NLS-1$
-        {
-            @Override
-            public Void execute(IBmTransaction transaction, IProgressMonitor monitor)
-            {
-                IBmObject commonModule = transaction.getTopObjectByFqn("CommonModule.ГМодуль");
-                Configuration configuration =
-                    transaction.toTransactionObject(((IConfigurationAware)v8Project).getConfiguration());
-                configuration.getCommonModules().remove((CommonModule)commonModule);
-                transaction.detachTopObject(commonModule);
-                return null;
-            }
-        });
-
-        waitSortStartedlatch.await();
-        // wait until sorting is completed.
-        TimeUnit.SECONDS.sleep(5);
-
-        IBmObject object = getTopObjectByFqn(CONFIGURATION.getName(), dtProject);
-        assertTrue(object instanceof Configuration);
-
-        Configuration configuration = (Configuration)object;
-        assertFalse(configuration.getCommonModules().isEmpty());
-
-        assertEquals("АМ_Модуль", configuration.getCommonModules().get(0).getName());
-        assertEquals("АМ2_4Модуль", configuration.getCommonModules().get(1).getName());
-        assertEquals("АМодуль", configuration.getCommonModules().get(2).getName());
-        assertEquals("БМодуль", configuration.getCommonModules().get(3).getName());
-        assertEquals("ОбщийМодуль", configuration.getCommonModules().get(4).getName());
-    }
-
-    @Ignore("G5V8DT-22608")
-    @Test
-    public void testSortAfterMoveEvent() throws Exception
-    {
-        IProject project = testingWorkspace.setUpProject(PROJECT_NAME, getClass());
-        assertNotNull(project);
-        IDtProject dtProject = dtProjectManager.getDtProject(project);
-        assertNotNull(dtProject);
-        IV8Project v8Project = v8ProjectManager.getProject(dtProject);
-        assertNotNull(dtProject);
-
-        IEclipsePreferences autoSortPrefs = AutoSortPreferences.getPreferences(project);
-        autoSortPrefs.putBoolean(AutoSortPreferences.KEY_ALL_TOP, true);
-        autoSortPrefs.flush();
-
-        IEclipsePreferences mdSortPrefs = MdSortPreferences.getPreferences(project);
-        mdSortPrefs.putBoolean(MdSortPreferences.NATURAL_SORT_ORDER, false);
-        mdSortPrefs.flush();
-
-        CountDownLatch waitSortStartedlatch = new CountDownLatch(1);
-        bmModelManager.addSyncEventListener(bmModelManager.getBmNamespace(project),
-            new BmEventListener(project, waitSortStartedlatch)
-            {
-                private int moveCount = 0;
-
-                @Override
-                protected void registerEvent(Notification notification)
-                {
-                    if (notification.getEventType() == Notification.MOVE)
-                    {
-                        moveCount++;
-                    }
-                }
-
-                @Override
-                protected boolean isShouldCountDownLatch()
-                {
-                    return moveCount == 2;
-                }
-            });
-
-        bmModelManager.getModel(project).execute(new AbstractBmTask<Void>("Move a top object") //$NON-NLS-1$
-        {
-            @Override
-            public Void execute(IBmTransaction transaction, IProgressMonitor progressMonitor)
-            {
-                IBmObject commonModule = transaction.getTopObjectByFqn("CommonModule.БМодуль");
-                Configuration configuration =
-                    transaction.toTransactionObject(((IConfigurationAware)v8Project).getConfiguration());
-                configuration.getCommonModules().move(4, (CommonModule)commonModule);
-                return null;
-            }
-        });
-
-        waitSortStartedlatch.await();
-        // wait until sorting is performed.
-        TimeUnit.SECONDS.sleep(5);
-
-        IBmObject object = getTopObjectByFqn(CONFIGURATION.getName(), dtProject);
-        assertTrue(object instanceof Configuration);
-
-        Configuration configuration = (Configuration)object;
-        assertFalse(configuration.getCommonModules().isEmpty());
-
-        assertEquals("АМ_Модуль", configuration.getCommonModules().get(0).getName());
-        assertEquals("АМ2_4Модуль", configuration.getCommonModules().get(1).getName());
-        assertEquals("АМодуль", configuration.getCommonModules().get(2).getName());
-        assertEquals("БМодуль", configuration.getCommonModules().get(3).getName());
-        assertEquals("ГМодуль", configuration.getCommonModules().get(4).getName());
-        assertEquals("ОбщийМодуль", configuration.getCommonModules().get(5).getName());
-    }
-
-    @Ignore("G5V8DT-22608")
-    @Test
-    public void testSortAfterAddEvent() throws Exception
-    {
-        IProject project = testingWorkspace.setUpProject(PROJECT_NAME, getClass());
-        assertNotNull(project);
-        IDtProject dtProject = dtProjectManager.getDtProject(project);
-        assertNotNull(dtProject);
-        IV8Project v8Project = v8ProjectManager.getProject(dtProject);
-        assertNotNull(dtProject);
-
-        IEclipsePreferences autoSortPrefs = AutoSortPreferences.getPreferences(project);
-        autoSortPrefs.putBoolean(AutoSortPreferences.KEY_ALL_TOP, true);
-        autoSortPrefs.flush();
-
-        IEclipsePreferences mdSortPrefs = MdSortPreferences.getPreferences(project);
-        mdSortPrefs.putBoolean(MdSortPreferences.NATURAL_SORT_ORDER, false);
-        mdSortPrefs.flush();
-
-        CountDownLatch waitSortStartedlatch = new CountDownLatch(1);
-        bmModelManager.addSyncEventListener(bmModelManager.getBmNamespace(project),
-            new BmEventListener(project, waitSortStartedlatch)
-            {
-                boolean isBmObjectAdded = false;
-                boolean isStortStarted = false;
-
-                @Override
-                protected void registerEvent(Notification notification)
-                {
-                    if (notification.getEventType() == Notification.ADD)
-                    {
-                        isBmObjectAdded = true;
-                    }
-                    else if (notification.getEventType() == Notification.MOVE)
-                    {
-                        isStortStarted = true;
-                    }
-                }
-
-                @Override
-                protected boolean isShouldCountDownLatch()
-                {
-                    return isBmObjectAdded && isStortStarted;
-                }
-            });
-
-        bmModelManager.getModel(project).execute(new AbstractBmTask<Void>("Add a top object") //$NON-NLS-1$
-        {
-            @Override
-            public Void execute(IBmTransaction transaction, IProgressMonitor progressMonitor)
-            {
-                CommonModule commonModule = MdClassFactory.eINSTANCE.createCommonModule();
-                commonModule.setName("КМодуль");
-                commonModule.setUuid(UUID.randomUUID());
-                transaction.attachTopObject((IBmObject)commonModule, "CommonModule.КМодуль");
-
-                Configuration configuration =
-                    transaction.toTransactionObject(((IConfigurationAware)v8Project).getConfiguration());
-
-                configuration.getCommonModules().add(commonModule);
-                return null;
-            }
-        });
-
-        waitSortStartedlatch.await();
-        // wait until sorting is performed.
-        TimeUnit.SECONDS.sleep(5);
-
-        IBmObject object = getTopObjectByFqn(CONFIGURATION.getName(), dtProject);
-        Configuration configuration = (Configuration)object;
-        assertFalse(configuration.getCommonModules().isEmpty());
-
-        assertEquals("АМ_Модуль", configuration.getCommonModules().get(0).getName());
-        assertEquals("АМ2_4Модуль", configuration.getCommonModules().get(1).getName());
-        assertEquals("АМодуль", configuration.getCommonModules().get(2).getName());
-        assertEquals("БМодуль", configuration.getCommonModules().get(3).getName());
-        assertEquals("ГМодуль", configuration.getCommonModules().get(4).getName());
-        assertEquals("КМодуль", configuration.getCommonModules().get(5).getName());
-        assertEquals("ОбщийМодуль", configuration.getCommonModules().get(6).getName());
-    }
+//    @Ignore("G5V8DT-22608")
+//    @Test
+//    public void testSortAfterRemoveEvent() throws Exception
+//    {
+//        IProject project = testingWorkspace.setUpProject(PROJECT_NAME, getClass());
+//        assertNotNull(project);
+//        IDtProject dtProject = dtProjectManager.getDtProject(project);
+//        assertNotNull(dtProject);
+//        IV8Project v8Project = v8ProjectManager.getProject(dtProject);
+//        assertNotNull(dtProject);
+//
+//        IEclipsePreferences autoSortPrefs = AutoSortPreferences.getPreferences(project);
+//        autoSortPrefs.putBoolean(AutoSortPreferences.KEY_ALL_TOP, true);
+//        autoSortPrefs.flush();
+//
+//        IEclipsePreferences mdSortPrefs = MdSortPreferences.getPreferences(project);
+//        mdSortPrefs.putBoolean(MdSortPreferences.NATURAL_SORT_ORDER, false);
+//        mdSortPrefs.flush();
+//
+//        CountDownLatch waitSortStartedlatch = new CountDownLatch(1);
+//        bmModelManager.addSyncEventListener(bmModelManager.getBmNamespace(project),
+//            new BmEventListener(project, waitSortStartedlatch)
+//            {
+//                boolean isBmObjectRemoved = false;
+//                boolean isStortStarted = false;
+//
+//                @Override
+//                protected void registerEvent(Notification notification)
+//                {
+//                    if (notification.getEventType() == Notification.REMOVE)
+//                    {
+//                        isBmObjectRemoved = true;
+//                    }
+//                    else if (notification.getEventType() == Notification.MOVE)
+//                    {
+//                        isStortStarted = true;
+//                    }
+//                }
+//
+//                @Override
+//                protected boolean isShouldCountDownLatch()
+//                {
+//                    return isBmObjectRemoved && isStortStarted;
+//                }
+//            });
+//
+//        bmModelManager.getModel(project).execute(new AbstractBmTask<Void>("Detach a top object") //$NON-NLS-1$
+//        {
+//            @Override
+//            public Void execute(IBmTransaction transaction, IProgressMonitor monitor)
+//            {
+//                IBmObject commonModule = transaction.getTopObjectByFqn("CommonModule.ГМодуль");
+//                Configuration configuration =
+//                    transaction.toTransactionObject(((IConfigurationAware)v8Project).getConfiguration());
+//                configuration.getCommonModules().remove((CommonModule)commonModule);
+//                transaction.detachTopObject(commonModule);
+//                return null;
+//            }
+//        });
+//
+//        waitSortStartedlatch.await();
+//        // wait until sorting is completed.
+//        TimeUnit.SECONDS.sleep(5);
+//
+//        IBmObject object = getTopObjectByFqn(CONFIGURATION.getName(), dtProject);
+//        assertTrue(object instanceof Configuration);
+//
+//        Configuration configuration = (Configuration)object;
+//        assertFalse(configuration.getCommonModules().isEmpty());
+//
+//        assertEquals("АМ_Модуль", configuration.getCommonModules().get(0).getName());
+//        assertEquals("АМ2_4Модуль", configuration.getCommonModules().get(1).getName());
+//        assertEquals("АМодуль", configuration.getCommonModules().get(2).getName());
+//        assertEquals("БМодуль", configuration.getCommonModules().get(3).getName());
+//        assertEquals("ОбщийМодуль", configuration.getCommonModules().get(4).getName());
+//    }
+//
+//    @Ignore("G5V8DT-22608")
+//    @Test
+//    public void testSortAfterMoveEvent() throws Exception
+//    {
+//        IProject project = testingWorkspace.setUpProject(PROJECT_NAME, getClass());
+//        assertNotNull(project);
+//        IDtProject dtProject = dtProjectManager.getDtProject(project);
+//        assertNotNull(dtProject);
+//        IV8Project v8Project = v8ProjectManager.getProject(dtProject);
+//        assertNotNull(dtProject);
+//
+//        IEclipsePreferences autoSortPrefs = AutoSortPreferences.getPreferences(project);
+//        autoSortPrefs.putBoolean(AutoSortPreferences.KEY_ALL_TOP, true);
+//        autoSortPrefs.flush();
+//
+//        IEclipsePreferences mdSortPrefs = MdSortPreferences.getPreferences(project);
+//        mdSortPrefs.putBoolean(MdSortPreferences.NATURAL_SORT_ORDER, false);
+//        mdSortPrefs.flush();
+//
+//        CountDownLatch waitSortStartedlatch = new CountDownLatch(1);
+//        bmModelManager.addSyncEventListener(bmModelManager.getBmNamespace(project),
+//            new BmEventListener(project, waitSortStartedlatch)
+//            {
+//                private int moveCount = 0;
+//
+//                @Override
+//                protected void registerEvent(Notification notification)
+//                {
+//                    if (notification.getEventType() == Notification.MOVE)
+//                    {
+//                        moveCount++;
+//                    }
+//                }
+//
+//                @Override
+//                protected boolean isShouldCountDownLatch()
+//                {
+//                    return moveCount == 2;
+//                }
+//            });
+//
+//        bmModelManager.getModel(project).execute(new AbstractBmTask<Void>("Move a top object") //$NON-NLS-1$
+//        {
+//            @Override
+//            public Void execute(IBmTransaction transaction, IProgressMonitor progressMonitor)
+//            {
+//                IBmObject commonModule = transaction.getTopObjectByFqn("CommonModule.БМодуль");
+//                Configuration configuration =
+//                    transaction.toTransactionObject(((IConfigurationAware)v8Project).getConfiguration());
+//                configuration.getCommonModules().move(4, (CommonModule)commonModule);
+//                return null;
+//            }
+//        });
+//
+//        waitSortStartedlatch.await();
+//        // wait until sorting is performed.
+//        TimeUnit.SECONDS.sleep(5);
+//
+//        IBmObject object = getTopObjectByFqn(CONFIGURATION.getName(), dtProject);
+//        assertTrue(object instanceof Configuration);
+//
+//        Configuration configuration = (Configuration)object;
+//        assertFalse(configuration.getCommonModules().isEmpty());
+//
+//        assertEquals("АМ_Модуль", configuration.getCommonModules().get(0).getName());
+//        assertEquals("АМ2_4Модуль", configuration.getCommonModules().get(1).getName());
+//        assertEquals("АМодуль", configuration.getCommonModules().get(2).getName());
+//        assertEquals("БМодуль", configuration.getCommonModules().get(3).getName());
+//        assertEquals("ГМодуль", configuration.getCommonModules().get(4).getName());
+//        assertEquals("ОбщийМодуль", configuration.getCommonModules().get(5).getName());
+//    }
+//
+//    @Ignore("G5V8DT-22608")
+//    @Test
+//    public void testSortAfterAddEvent() throws Exception
+//    {
+//        IProject project = testingWorkspace.setUpProject(PROJECT_NAME, getClass());
+//        assertNotNull(project);
+//        IDtProject dtProject = dtProjectManager.getDtProject(project);
+//        assertNotNull(dtProject);
+//        IV8Project v8Project = v8ProjectManager.getProject(dtProject);
+//        assertNotNull(dtProject);
+//
+//        IEclipsePreferences autoSortPrefs = AutoSortPreferences.getPreferences(project);
+//        autoSortPrefs.putBoolean(AutoSortPreferences.KEY_ALL_TOP, true);
+//        autoSortPrefs.flush();
+//
+//        IEclipsePreferences mdSortPrefs = MdSortPreferences.getPreferences(project);
+//        mdSortPrefs.putBoolean(MdSortPreferences.NATURAL_SORT_ORDER, false);
+//        mdSortPrefs.flush();
+//
+//        CountDownLatch waitSortStartedlatch = new CountDownLatch(1);
+//        bmModelManager.addSyncEventListener(bmModelManager.getBmNamespace(project),
+//            new BmEventListener(project, waitSortStartedlatch)
+//            {
+//                boolean isBmObjectAdded = false;
+//                boolean isStortStarted = false;
+//
+//                @Override
+//                protected void registerEvent(Notification notification)
+//                {
+//                    if (notification.getEventType() == Notification.ADD)
+//                    {
+//                        isBmObjectAdded = true;
+//                    }
+//                    else if (notification.getEventType() == Notification.MOVE)
+//                    {
+//                        isStortStarted = true;
+//                    }
+//                }
+//
+//                @Override
+//                protected boolean isShouldCountDownLatch()
+//                {
+//                    return isBmObjectAdded && isStortStarted;
+//                }
+//            });
+//
+//        bmModelManager.getModel(project).execute(new AbstractBmTask<Void>("Add a top object") //$NON-NLS-1$
+//        {
+//            @Override
+//            public Void execute(IBmTransaction transaction, IProgressMonitor progressMonitor)
+//            {
+//                CommonModule commonModule = MdClassFactory.eINSTANCE.createCommonModule();
+//                commonModule.setName("КМодуль");
+//                commonModule.setUuid(UUID.randomUUID());
+//                transaction.attachTopObject((IBmObject)commonModule, "CommonModule.КМодуль");
+//
+//                Configuration configuration =
+//                    transaction.toTransactionObject(((IConfigurationAware)v8Project).getConfiguration());
+//
+//                configuration.getCommonModules().add(commonModule);
+//                return null;
+//            }
+//        });
+//
+//        waitSortStartedlatch.await();
+//        // wait until sorting is performed.
+//        TimeUnit.SECONDS.sleep(5);
+//
+//        IBmObject object = getTopObjectByFqn(CONFIGURATION.getName(), dtProject);
+//        Configuration configuration = (Configuration)object;
+//        assertFalse(configuration.getCommonModules().isEmpty());
+//
+//        assertEquals("АМ_Модуль", configuration.getCommonModules().get(0).getName());
+//        assertEquals("АМ2_4Модуль", configuration.getCommonModules().get(1).getName());
+//        assertEquals("АМодуль", configuration.getCommonModules().get(2).getName());
+//        assertEquals("БМодуль", configuration.getCommonModules().get(3).getName());
+//        assertEquals("ГМодуль", configuration.getCommonModules().get(4).getName());
+//        assertEquals("КМодуль", configuration.getCommonModules().get(5).getName());
+//        assertEquals("ОбщийМодуль", configuration.getCommonModules().get(6).getName());
+//    }
 
     protected IBmObject getTopObjectByFqn(final String fqn, IDtProject dtProject)
     {


### PR DESCRIPTION
Добавил триггер автосортировки на перемещение (MOVE) и удаление (REMOVE) фичи в коллекции. Проблема была связана с базами, а с отсутствием триггеров на эти события 