### PR TITLE
Проверка redundant-export-method исключена из настроек

### DIFF
--- a/bundles/com.e1c.v8codestyle.bsl/src/com/e1c/v8codestyle/bsl/check/RedundantExportMethodCheck.java
+++ b/bundles/com.e1c.v8codestyle.bsl/src/com/e1c/v8codestyle/bsl/check/RedundantExportMethodCheck.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package com.e1c.v8codestyle.bsl.check;
 
-import static com._1c.g5.v8.dt.bsl.model.BslPackage.Literals.METHOD;
 import static org.eclipse.xtext.resource.impl.ResourceDescriptionsProvider.PERSISTED_DESCRIPTIONS;
 
 import java.text.MessageFormat;
@@ -54,10 +53,7 @@ import com._1c.g5.v8.dt.bsl.model.StringLiteral;
 import com._1c.g5.v8.dt.common.StringUtils;
 import com._1c.g5.v8.dt.mcore.util.McoreUtil;
 import com._1c.g5.v8.dt.metadata.mdclass.MdClassPackage;
-import com.e1c.g5.v8.dt.check.CheckComplexity;
 import com.e1c.g5.v8.dt.check.ICheckParameters;
-import com.e1c.g5.v8.dt.check.settings.IssueSeverity;
-import com.e1c.g5.v8.dt.check.settings.IssueType;
 import com.e1c.v8codestyle.bsl.ModuleStructureSection;
 import com.google.inject.Inject;
 
@@ -114,7 +110,8 @@ public final class RedundantExportMethodCheck
     @Override
     protected void configureCheck(CheckConfigurer builder)
     {
-        builder.title(Messages.RedundantExportCheck_Escess_title)
+        //TODO Переделать реализацию проверки в рамках задачи #314
+        /* builder.title(Messages.RedundantExportCheck_Escess_title)
             .description(Messages.RedundantExportCheck_Excess_description)
             .complexity(CheckComplexity.NORMAL)
             .severity(IssueSeverity.MINOR)
@@ -122,11 +119,10 @@ public final class RedundantExportMethodCheck
             .disable()
             .extension(ModuleTypeFilter.onlyTypes(ModuleType.MANAGER_MODULE, ModuleType.COMMON_MODULE,
                 ModuleType.OBJECT_MODULE))
-            //.extension(new StandardCheckExtension(getCheckId(), BslPlugin.PLUGIN_ID))
             .module()
             .checkedObjectType(METHOD)
             .parameter(PARAMETER_EXCLUDE_REGION_LIST, String.class, DEFAULT_EXCLUDE_REGION_NAME_LIST,
-                Messages.RedundantExportCheck_Exclude_title);
+                Messages.RedundantExportCheck_Exclude_title);*/
 
     }
 

--- a/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/check/itests/RedundantExportMethodCheckTest.java
+++ b/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/check/itests/RedundantExportMethodCheckTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.Path;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com._1c.g5.v8.dt.validation.marker.IExtraInfoKeys;
@@ -51,6 +52,7 @@ public class RedundantExportMethodCheckTest
         return PROJECT_NAME;
     }
 
+    @Ignore
     @Test
     public void testNoCallNoPublic() throws Exception
     {
@@ -60,6 +62,7 @@ public class RedundantExportMethodCheckTest
         assertEquals("1", markers.get(0).getExtraInfo().get(IExtraInfoKeys.TEXT_EXTRA_INFO_LINE_KEY));
     }
 
+    @Ignore
     @Test
     public void testNoCallPublic() throws Exception
     {
@@ -67,6 +70,7 @@ public class RedundantExportMethodCheckTest
         assertEquals(0, markers.size());
     }
 
+    @Ignore
     @Test
     public void testCallNoPublic() throws Exception
     {
@@ -74,6 +78,7 @@ public class RedundantExportMethodCheckTest
         assertEquals(0, markers.size());
     }
 
+    @Ignore
     @Test
     public void testLocalCall() throws Exception
     {
@@ -83,6 +88,7 @@ public class RedundantExportMethodCheckTest
         assertEquals("2", markers.get(0).getExtraInfo().get(IExtraInfoKeys.TEXT_EXTRA_INFO_LINE_KEY));
     }
 
+    @Ignore
     @Test
     public void testNotifyCall() throws Exception
     {
@@ -90,6 +96,7 @@ public class RedundantExportMethodCheckTest
         assertEquals(0, markers.size());
     }
 
+    @Ignore
     @Test
     public void testNotifyWithRegionCall() throws Exception
     {
@@ -97,6 +104,7 @@ public class RedundantExportMethodCheckTest
         assertEquals(0, markers.size());
     }
 
+    @Ignore
     @Test
     public void testEventSubscription() throws Exception
     {
@@ -104,6 +112,7 @@ public class RedundantExportMethodCheckTest
         assertEquals(0, markers.size());
     }
 
+    @Ignore
     @Test
     public void testScheduledJob() throws Exception
     {


### PR DESCRIPTION
## Что сделано

Проверка redundant-export-method выедена из использания, до реализации задачи #314 , так как текущая реализация может давать ложные срабатыаения.

## Чек-лист

<!-- 
Перед отправкой вашего PR на аудит пройдите по чек-листу, выполните задачи, отметьте каждый пункт (если применимо).
Если что-то не понятно - лучше уточните в чате.
-->

Общее:
- [ ] ветка PR обновлена из `master` и нет конфликтов
- [ ] Тесты-кейсы, JUnit тесты правильного и неправильного состояния
- [ ] Измененные Вами исходники отформатированы в соответствии [с конвенцией](https://github.com/1C-Company/v8-code-style/blob/master/docs/contributing/code_style.md)
- [ ] Авто-аудит (SonarQube и CheckStyle) пройден, покрытие кода хорошее, ошибок нет, плохой код устранен
- [ ] Добавлена запись в [ИСТОРИЮ ИЗМЕНЕНИЯ](https://github.com/1C-Company/v8-code-style/blob/master/CHANGELOG.md), включаемая в пользовательскую документацию плагина

Если применимо:
- [ ] Пользовательская документация на доп.инструменты написана (на русском)
- [ ] Описание проверок - на двух языках

## Закрываемые задачи

<!-- 
Укажите номер закрываемой задачи (обязательно!)
Например: Closes #123
-->

Closes #1381

<!-- 
С реквестом можно работать долго в статусе Draft (черновик).
По окончании работ, выполнению чек-листа - добавьте комментарий для начала аудита:
@1C-Company @marmyshev прошу сделать аудит
-->
