### PR TITLE
G5V8DT-25849 Нет переноса строки при создании новой области в модуле

### DIFF
--- a/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/internal/bsl/ui/services/BslModuleRegionsInfo.java
+++ b/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/internal/bsl/ui/services/BslModuleRegionsInfo.java
@@ -24,21 +24,10 @@ import com._1c.g5.v8.dt.bsl.common.IBslModuleTextInsertInfo;
 public class BslModuleRegionsInfo
     implements IBslModuleTextInsertInfo
 {
-    /**
-     * Has region before offset position
-     */
-    public static final int REGION_FLAG_HAS_REGION_BEFORE = 1;
-
-    /**
-     * Has region after offset position
-     */
-    public static final int REGION_FLAG_HAS_REGION_AFTER = 2;
-
     private final URI resourceURI;
     private final int insertPosition;
     private final int clearPosition;
     private final int clearLength;
-    private final int regionFlags;
     private final String regionName;
 
     /**
@@ -48,17 +37,15 @@ public class BslModuleRegionsInfo
      * @param insertPosition <code>int</code> insertion offset, cannot be negative
      * @param clearPosition text clear <code>int</code> position, can be negative if no clear needed
      * @param clearLength text clear <code>int</code> length, can be negative if no clear needed
-     * @param regionFlags region <code>int</code> flags represents regions states, cannot be negative
      * @param regionName {@link String} region name, can be <code>null</code>
      */
     public BslModuleRegionsInfo(URI resourceURI, int insertPosition, int clearPosition, int clearLength,
-        int regionFlags, String regionName)
+        String regionName)
     {
         this.resourceURI = resourceURI;
         this.insertPosition = insertPosition;
         this.clearPosition = clearPosition;
         this.clearLength = clearLength;
-        this.regionFlags = regionFlags;
         this.regionName = regionName;
     }
 
@@ -78,16 +65,6 @@ public class BslModuleRegionsInfo
     public int getClearLength()
     {
         return clearLength;
-    }
-
-    /**
-     * Returns flags which represents regions states
-     *
-     * @return <code>int</code> flags, cannot be negative
-     */
-    public int getRegionFlags()
-    {
-        return regionFlags;
     }
 
     /**

--- a/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/internal/bsl/ui/services/BslModuleRegionsInfo.java
+++ b/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/internal/bsl/ui/services/BslModuleRegionsInfo.java
@@ -24,10 +24,21 @@ import com._1c.g5.v8.dt.bsl.common.IBslModuleTextInsertInfo;
 public class BslModuleRegionsInfo
     implements IBslModuleTextInsertInfo
 {
+    /**
+     * Has region before offset position
+     */
+    public static final int REGION_FLAG_HAS_REGION_BEFORE = 1;
+
+    /**
+     * Has region after offset position
+     */
+    public static final int REGION_FLAG_HAS_REGION_AFTER = 2;
+
     private final URI resourceURI;
     private final int insertPosition;
     private final int clearPosition;
     private final int clearLength;
+    private final int regionFlags;
     private final String regionName;
 
     /**
@@ -37,15 +48,17 @@ public class BslModuleRegionsInfo
      * @param insertPosition <code>int</code> insertion offset, cannot be negative
      * @param clearPosition text clear <code>int</code> position, can be negative if no clear needed
      * @param clearLength text clear <code>int</code> length, can be negative if no clear needed
+     * @param regionFlags region <code>int</code> flags represents regions states, cannot be negative
      * @param regionName {@link String} region name, can be <code>null</code>
      */
     public BslModuleRegionsInfo(URI resourceURI, int insertPosition, int clearPosition, int clearLength,
-        String regionName)
+        int regionFlags, String regionName)
     {
         this.resourceURI = resourceURI;
         this.insertPosition = insertPosition;
         this.clearPosition = clearPosition;
         this.clearLength = clearLength;
+        this.regionFlags = regionFlags;
         this.regionName = regionName;
     }
 
@@ -65,6 +78,16 @@ public class BslModuleRegionsInfo
     public int getClearLength()
     {
         return clearLength;
+    }
+
+    /**
+     * Returns flags which represents regions states
+     *
+     * @return <code>int</code> flags, cannot be negative
+     */
+    public int getRegionFlags()
+    {
+        return regionFlags;
     }
 
     /**

--- a/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/internal/bsl/ui/services/BslModuleRegionsInfoService.java
+++ b/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/internal/bsl/ui/services/BslModuleRegionsInfoService.java
@@ -107,8 +107,7 @@ public class BslModuleRegionsInfoService
         {
             regionName = suffix.isEmpty() ? declaredRegionName : (declaredRegionName + suffix);
         }
-        int flags = calculateFlags(project, regionOffsets, offset);
-        return new BslModuleRegionsInfo(resourceURI, offset, clearOffset, clearLength, flags, regionName);
+        return new BslModuleRegionsInfo(resourceURI, offset, clearOffset, clearLength, regionName);
     }
 
     @Override
@@ -130,11 +129,6 @@ public class BslModuleRegionsInfoService
                 String endRegion = proposals.getEndRegionPropStr();
                 String space = proposals.getSpacePropStr();
                 StringBuilder builder = new StringBuilder();
-                int flags = moduleRegionInformation.getRegionFlags();
-                boolean hasRegionBefore = (flags
-                    & BslModuleRegionsInfo.REGION_FLAG_HAS_REGION_BEFORE) == BslModuleRegionsInfo.REGION_FLAG_HAS_REGION_BEFORE;
-                boolean hasRegionAfter = (flags
-                    & BslModuleRegionsInfo.REGION_FLAG_HAS_REGION_AFTER) == BslModuleRegionsInfo.REGION_FLAG_HAS_REGION_AFTER;
                 if (moduleTextInsertInfo.getPosition() != 0)
                 {
                     builder.append(lineSeparator);
@@ -142,7 +136,7 @@ public class BslModuleRegionsInfoService
                 builder.append(beginRegion).append(space).append(regionName);
                 builder.append(content);
                 builder.append(endRegion);
-                if (moduleTextInsertInfo.getPosition() == 0 || (hasRegionAfter && !hasRegionBefore))
+                if (moduleTextInsertInfo.getPosition() == 0)
                 {
                     builder.append(lineSeparator);
                 }
@@ -244,23 +238,6 @@ public class BslModuleRegionsInfoService
             return getNewRegionOffset(regionOffsets, declaredRegionName, suffix, defaultOffset, scriptVariant);
         }
         return offset;
-    }
-
-    private int calculateFlags(IV8Project project, Map<String, BslModuleOffsets> regionOffsets, int offset)
-    {
-        int flags = 0;
-        for (BslModuleOffsets offsets : regionOffsets.values())
-        {
-            if (offsets.getEndOffset() <= offset)
-            {
-                flags |= BslModuleRegionsInfo.REGION_FLAG_HAS_REGION_BEFORE;
-            }
-            if (offsets.getStartOffset() >= offset)
-            {
-                flags |= BslModuleRegionsInfo.REGION_FLAG_HAS_REGION_AFTER;
-            }
-        }
-        return flags;
     }
 
     private boolean isRegionExists(Map<String, BslModuleOffsets> regionOffsets, String declaredRegionName,

--- a/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/internal/bsl/ui/services/BslModuleRegionsInfoService.java
+++ b/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/internal/bsl/ui/services/BslModuleRegionsInfoService.java
@@ -136,10 +136,7 @@ public class BslModuleRegionsInfoService
                 builder.append(beginRegion).append(space).append(regionName);
                 builder.append(content);
                 builder.append(endRegion);
-                if (moduleTextInsertInfo.getPosition() == 0)
-                {
-                    builder.append(lineSeparator);
-                }
+                builder.append(lineSeparator);
                 return builder.toString();
             }
         }

--- a/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/internal/bsl/ui/services/BslModuleRegionsInfoService.java
+++ b/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/internal/bsl/ui/services/BslModuleRegionsInfoService.java
@@ -107,7 +107,8 @@ public class BslModuleRegionsInfoService
         {
             regionName = suffix.isEmpty() ? declaredRegionName : (declaredRegionName + suffix);
         }
-        return new BslModuleRegionsInfo(resourceURI, offset, clearOffset, clearLength, regionName);
+        int flags = calculateFlags(project, regionOffsets, offset);
+        return new BslModuleRegionsInfo(resourceURI, offset, clearOffset, clearLength, flags, regionName);
     }
 
     @Override
@@ -129,6 +130,11 @@ public class BslModuleRegionsInfoService
                 String endRegion = proposals.getEndRegionPropStr();
                 String space = proposals.getSpacePropStr();
                 StringBuilder builder = new StringBuilder();
+                int flags = moduleRegionInformation.getRegionFlags();
+                boolean hasRegionBefore = (flags
+                    & BslModuleRegionsInfo.REGION_FLAG_HAS_REGION_BEFORE) == BslModuleRegionsInfo.REGION_FLAG_HAS_REGION_BEFORE;
+                boolean hasRegionAfter = (flags
+                    & BslModuleRegionsInfo.REGION_FLAG_HAS_REGION_AFTER) == BslModuleRegionsInfo.REGION_FLAG_HAS_REGION_AFTER;
                 if (moduleTextInsertInfo.getPosition() != 0)
                 {
                     builder.append(lineSeparator);
@@ -136,7 +142,7 @@ public class BslModuleRegionsInfoService
                 builder.append(beginRegion).append(space).append(regionName);
                 builder.append(content);
                 builder.append(endRegion);
-                if (moduleTextInsertInfo.getPosition() == 0)
+                if (moduleTextInsertInfo.getPosition() == 0 || (hasRegionAfter && !hasRegionBefore))
                 {
                     builder.append(lineSeparator);
                 }
@@ -238,6 +244,23 @@ public class BslModuleRegionsInfoService
             return getNewRegionOffset(regionOffsets, declaredRegionName, suffix, defaultOffset, scriptVariant);
         }
         return offset;
+    }
+
+    private int calculateFlags(IV8Project project, Map<String, BslModuleOffsets> regionOffsets, int offset)
+    {
+        int flags = 0;
+        for (BslModuleOffsets offsets : regionOffsets.values())
+        {
+            if (offsets.getEndOffset() <= offset)
+            {
+                flags |= BslModuleRegionsInfo.REGION_FLAG_HAS_REGION_BEFORE;
+            }
+            if (offsets.getStartOffset() >= offset)
+            {
+                flags |= BslModuleRegionsInfo.REGION_FLAG_HAS_REGION_AFTER;
+            }
+        }
+        return flags;
     }
 
     private boolean isRegionExists(Map<String, BslModuleOffsets> regionOffsets, String declaredRegionName,


### PR DESCRIPTION
## Что сделано

Исправления по G5V8DT-25849 (перенос строки при создании новой области в модуле)

## Чек-лист

Общее:
- [x] ветка PR обновлена из `edt-2024-2` и нет конфликтов
- [x] Измененные Вами исходники отформатированы в соответствии [с конвенцией](https://github.com/1C-Company/v8-code-style/blob/master/docs/contributing/code_style.md)

@MaksimDzyuba прошу сделать аудит
