### PR TITLE
G5V8DT-24085 DcsOutputParameters содержит несуществующие поля

### DIFF
--- a/tests/com.e1c.v8codestyle.ql.itests/META-INF/MANIFEST.MF
+++ b/tests/com.e1c.v8codestyle.ql.itests/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: fragment
 Import-Package: com._1c.g5.v8.bm.integration;version="[11.0.0,12.0.0)",
  com._1c.g5.v8.dt.core.platform;version="[11.0.0,12.0.0)",
- com._1c.g5.v8.dt.dcs.util;version="[14.0.0,15.0.0)",
+ com._1c.g5.v8.dt.dcs.util;version="[15.0.0,16.0.0)",
  com._1c.g5.v8.dt.form.model;version="[12.0.0,13.0.0)",
  com._1c.g5.v8.dt.mcore;version="[7.0.0,8.0.0)",
  com._1c.g5.v8.dt.testing;version="[3.0.0,4.0.0)",


### PR DESCRIPTION
Versioning

## Что сделано

Версии из-за G5V8DT-24085

## Чек-лист

Общее:
- [x] ветка PR обновлена из `edt-2024-2` и нет конфликтов

@MaksimDzyuba прошу сделать аудит
