### PR TITLE
NPE "deleteInvocation" is null

### DIFF
--- a/bundles/com.e1c.v8codestyle.bsl/src/com/e1c/v8codestyle/bsl/strict/check/TypedValueAddingToUntypedCollectionCheck.java
+++ b/bundles/com.e1c.v8codestyle.bsl/src/com/e1c/v8codestyle/bsl/strict/check/TypedValueAddingToUntypedCollectionCheck.java
@@ -136,7 +136,7 @@ public class TypedValueAddingToUntypedCollectionCheck
             return;
         }
 
-        Collection<TypeItem> actualTypes = getActualCollectionTypes(fa, expectedCollectionTypes);
+        Collection<TypeItem> actualTypes = getActualCollectionTypes(fa, expectedCollectionTypes, monitor);
 
         if (!actualTypes.isEmpty() && isActualCollectionItemTypeEmpty(actualTypes))
         {
@@ -155,7 +155,7 @@ public class TypedValueAddingToUntypedCollectionCheck
 
         Invocation inv = BslUtil.getInvocation(fa);
 
-        if (!(inv.getMethodAccess() instanceof DynamicFeatureAccess))
+        if (inv == null || !(inv.getMethodAccess() instanceof DynamicFeatureAccess))
         {
             return expectedTypes;
         }
@@ -188,14 +188,26 @@ public class TypedValueAddingToUntypedCollectionCheck
         return expectedTypes;
     }
 
-    private Collection<TypeItem> getActualCollectionTypes(FeatureAccess fa, Collection<TypeItem> expectedTypes)
+    private Collection<TypeItem> getActualCollectionTypes(FeatureAccess fa, Collection<TypeItem> expectedTypes, IProgressMonitor monitor)
     {
         Collection<TypeItem> actualTypes = new ArrayList<>();
-        Invocation inv = BslUtil.getInvocation(fa);
+        if (monitor.isCanceled())
+        {
+            return actualTypes;
+        }
+        Invocation invocation = BslUtil.getInvocation(fa);
+        if (invocation == null)
+        {
+            return actualTypes;
+        }
 
         for (TypeItem type : expectedTypes)
         {
-            type = (TypeItem)EcoreUtil.resolve(type, inv);
+            if (monitor.isCanceled())
+            {
+                break;
+            }
+            type = (TypeItem)EcoreUtil.resolve(type, invocation);
 
             if (type.getName().equals(IEObjectTypeNames.VALUE_LIST))
             {


### PR DESCRIPTION
## Что сделано

Исправлено NPE на проверке, добавлены мониторы в методы с циклами

```
Получил стек трейс при сборке ЕРП на мастере. 

 

{{!ENTRY com.e1c.g5.v8.dt.check 4 0 2025-04-08 11:38:39.323
!MESSAGE Language check thrown an exception:false
!STACK 0
java.lang.NullPointerException: Cannot invoke "com._1c.g5.v8.dt.bsl.model.Invocation.getParams()" because "deleteInvocation" is null
at com.e1c.v8codestyle.bsl.check.MissingTemporaryFileDeletionCheck.checkParameterInList(MissingTemporaryFileDeletionCheck.java:152)
at com.e1c.v8codestyle.bsl.check.MissingTemporaryFileDeletionCheck.checkFileCloses(MissingTemporaryFileDeletionCheck.java:126)
at com.e1c.v8codestyle.bsl.check.MissingTemporaryFileDeletionCheck.check(MissingTemporaryFileDeletionCheck.java:102)
at com.e1c.g5.v8.dt.check.components.BasicCheck.check(BasicCheck.java:200)
at com.e1c.g5.v8.dt.check.components.BasicCheck.check(BasicCheck.java:76)
at com.e1c.g5.v8.dt.internal.check.CheckExecutor.runLanguageChecks(CheckExecutor.java:733)
at com.e1c.g5.v8.dt.internal.check.CheckExecutor.validateLanguage(CheckExecutor.java:215)
at com.e1c.g5.v8.dt.internal.check.bsl.BslValidationContributor.validate(BslValidationContributor.java:177)
at com._1c.g5.v8.dt.bsl.validation.IBslValidationContributor$pbryglu.validate(Unknown Source)
at com._1c.g5.v8.dt.bsl.validation.ExternalValidatorServiceProvider.validate(ExternalValidatorServiceProvider.java:78)
at com._1c.g5.v8.dt.bsl.validation.BslCancelableDiagnostician$CustomValidatorProcessor.doValidate(BslCancelableDiagnostician.java:290)
at com._1c.g5.v8.dt.bsl.common.ValidatorProcessor.doProcessInternal(ValidatorProcessor.java:505)
at com._1c.g5.v8.dt.bsl.common.ValidatorProcessor.doProcessInternal(ValidatorProcessor.java:458)
at com._1c.g5.v8.dt.bsl.common.ValidatorProcessor.doProcessInternal(ValidatorProcessor.java:522)
at com._1c.g5.v8.dt.bsl.common.ValidatorProcessor.doProcessInternal(ValidatorProcessor.java:462)
at com._1c.g5.v8.dt.bsl.common.ValidatorProcessor.doProcessInternal(ValidatorProcessor.java:312)
at com._1c.g5.v8.dt.bsl.common.ValidatorProcessor.doProcessInternal(ValidatorProcessor.java:259)
at com._1c.g5.v8.dt.bsl.common.ValidatorProcessor.doProcessInternal(ValidatorProcessor.java:249)
at com._1c.g5.v8.dt.bsl.common.ValidatorProcessor.doProcessInternal(ValidatorProcessor.java:190)
at com._1c.g5.v8.dt.bsl.common.ValidatorProcessor.doProcessInternal(ValidatorProcessor.java:261)
at com._1c.g5.v8.dt.bsl.common.ValidatorProcessor.doProcessInternal(ValidatorProcessor.java:249)
at com._1c.g5.v8.dt.bsl.common.ValidatorProcessor.doProcessInternal(ValidatorProcessor.java:384)
at com._1c.g5.v8.dt.bsl.common.ValidatorProcessor.doProcessInternal(ValidatorProcessor.java:283)
at com._1c.g5.v8.dt.bsl.common.ValidatorProcessor.doProcessInternal(ValidatorProcessor.java:249)
at com._1c.g5.v8.dt.bsl.common.ValidatorProcessor.validate(ValidatorProcessor.java:158)
at com._1c.g5.v8.dt.bsl.validation.BslCancelableDiagnostician.doValidateContents(BslCancelableDiagnostician.java:159)
at com._1c.g5.modeling.xtext.validation.CustomCancelableDiagnostician.validate(CustomCancelableDiagnostician.java:71)
at com._1c.g5.modeling.xtext.validation.CustomCancelableDiagnostician.validate(CustomCancelableDiagnostician.java:84)
at org.eclipse.emf.ecore.util.Diagnostician.validate(Diagnostician.java:142)
at org.eclipse.xtext.validation.ResourceValidatorImpl.validate(ResourceValidatorImpl.java:147)
at org.eclipse.xtext.validation.ResourceValidatorImpl.validate(ResourceValidatorImpl.java:125)
at org.eclipse.xtext.validation.ResourceValidatorImpl.validate(ResourceValidatorImpl.java:91)
at com._1c.g5.v8.dt.lcore.validation.NotifyingResourceValidator.validate(NotifyingResourceValidator.java:51)
at com._1c.g5.v8.dt.bsl.validation.BslNotifyingResourceValidator.validate(BslNotifyingResourceValidator.java:114)
at com._1c.g5.v8.dt.internal.bsl.bm.ui.deepanalysis.BslDeepAnalisysService.performXtextResourceValidation(BslDeepAnalisysService.java:431)
at com._1c.g5.v8.dt.internal.bsl.bm.ui.deepanalysis.BslDeepAnalisysService$3.execute(BslDeepAnalisysService.java:238)
at com._1c.g5.v8.dt.internal.bsl.bm.ui.deepanalysis.BslDeepAnalisysService$3.execute(BslDeepAnalisysService.java:1)
at com._1c.g5.v8.dt.internal.core.platform.bm.integration.LegacyTaskWrapper.execute(LegacyTaskWrapper.java:48)
at com._1c.g5.v8.dt.internal.core.platform.bm.integration.reactor.Reactor.executeTask(Reactor.java:842)
at com._1c.g5.v8.dt.internal.core.platform.bm.integration.reactor.Reactor.executeTask(Reactor.java:777)
at com._1c.g5.v8.dt.internal.core.platform.bm.integration.reactor.Reactor.executeReadOnlyTask(Reactor.java:151)
at com._1c.g5.v8.dt.internal.core.platform.bm.integration.BmModel.executeReadonlyTask(BmModel.java:225)
at com._1c.g5.v8.dt.internal.core.platform.bm.integration.BmModel.executeReadonlyTask(BmModel.java:216)
at com._1c.g5.v8.dt.internal.bsl.bm.ui.deepanalysis.BslDeepAnalisysService.performDeepAnalisys(BslDeepAnalisysService.java:228)
at com._1c.g5.v8.dt.bsl.validation.IBslDeepAnalisysService$pbryglu.performDeepAnalisys(Unknown Source)
at com.e1c.g5.v8.dt.internal.check.derived.LanguageCheckDerivedDataComputer.compute(LanguageCheckDerivedDataComputer.java:106)
at com._1c.g5.v8.internal.derived.WorkerManager$TaskProcessor.processTask(WorkerManager.java:370)
at com._1c.g5.v8.internal.derived.WorkerManager$TaskProcessor.call(WorkerManager.java:172)
at com._1c.g5.v8.internal.derived.WorkerManager$TaskProcessor.call(WorkerManager.java:1)
at com._1c.g5.v8.internal.derived.scheduler.DerivedDataExecutorPool$3.get(DerivedDataExecutorPool.java:315)
at com._1c.g5.v8.internal.derived.scheduler.DerivedDataExecutorPool$3.get(DerivedDataExecutorPool.java:1)
at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
at java.base/java.lang.Thread.run(Thread.java:833)}}
``` 