### PR TITLE
Добавлен QuickFix в проверке notify-description-to-server-procedure-error

### DIFF
--- a/bundles/com.e1c.v8codestyle.bsl.ui/plugin.xml
+++ b/bundles/com.e1c.v8codestyle.bsl.ui/plugin.xml
@@ -401,6 +401,9 @@
     <fix
           class="com.e1c.v8codestyle.internal.bsl.ui.ExecutableExtensionFactory:com.e1c.v8codestyle.bsl.ui.qfix.RestrictionExecuteExternalCodeFix">
     </fix>
+    <fix
+          class="com.e1c.v8codestyle.internal.bsl.ui.ExecutableExtensionFactory:com.e1c.v8codestyle.bsl.ui.qfix.NotifyDescriptionToServerProcedureFix">
+    </fix>
  </extension>
  <extension
        point="com._1c.g5.v8.dt.bsl.ui.bslModuleTextInsertInfoService">

--- a/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/Messages.java
+++ b/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/Messages.java
@@ -79,6 +79,9 @@ final class Messages
     public static String LinkPartSpaceFix_Description;
     public static String LinkPartSpaceFix_Details;
 
+    public static String NotifyDescriptionToServerProcedureFix_Description;
+    public static String NotifyDescriptionToServerProcedureFix_Details;
+
     static
     {
         // initialize resource bundle

--- a/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/NotifyDescriptionToServerProcedureFix.java
+++ b/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/NotifyDescriptionToServerProcedureFix.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (C) 2026, 1C-Soft LLC and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     1C-Soft LLC - initial API and implementation
+ *******************************************************************************/
+package com.e1c.v8codestyle.bsl.ui.qfix;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.text.edits.TextEdit;
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
+import org.eclipse.xtext.resource.XtextResource;
+
+import com._1c.g5.v8.dt.metadata.mdclass.ScriptVariant;
+import com.e1c.g5.v8.dt.bsl.check.qfix.IXtextBslModuleFixModel;
+import com.e1c.g5.v8.dt.bsl.check.qfix.IXtextInteractiveBslModuleFixModel;
+import com.e1c.g5.v8.dt.bsl.check.qfix.SingleVariantXtextBslModuleFix;
+import com.e1c.g5.v8.dt.check.qfix.components.QuickFix;
+
+/**
+ *  Create new method
+ *
+ *  @author Artem Samohvalov
+ */
+@QuickFix(checkId = "notify-description-to-server-procedure", supplierId = "com.e1c.v8codestyle.bsl")
+public class NotifyDescriptionToServerProcedureFix
+    extends SingleVariantXtextBslModuleFix
+{
+    private static final String AT_CLIENT_KEYWORD = "AtClient"; //$NON-NLS-1$
+    private static final String AT_CLIENT_KEYWORD_RU = "НаКлиенте"; //$NON-NLS-1$
+
+    @Override
+    protected void configureFix(FixConfigurer configurer)
+    {
+        configurer.interactive(true)
+            .description(Messages.NotifyDescriptionToServerProcedureFix_Description)
+            .details(Messages.NotifyDescriptionToServerProcedureFix_Details);
+    }
+
+    @Override
+    protected TextEdit fixIssue(XtextResource state, IXtextBslModuleFixModel model) throws BadLocationException
+    {
+        EObject element = model.getElement();
+        String stringValue = NodeModelUtils.getNode(element).getText();
+        String methodName = QuickFixMethodsHelper.getMethodName(stringValue.replace("\"", "")); //$NON-NLS-1$//$NON-NLS-2$
+
+        QuickFixMethodsHelper.createMethod((IXtextInteractiveBslModuleFixModel)model, methodName, false, true,
+            getAtClientKeyword(model));
+
+        return null;
+    }
+
+    private String getAtClientKeyword(IXtextBslModuleFixModel model)
+    {
+        boolean isRussian = model.getScriptVariant() == ScriptVariant.RUSSIAN;
+        return isRussian ? AT_CLIENT_KEYWORD_RU : AT_CLIENT_KEYWORD;
+    }
+}

--- a/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/NotifyDescriptionToServerProcedureFix.java
+++ b/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/NotifyDescriptionToServerProcedureFix.java
@@ -57,6 +57,6 @@ public class NotifyDescriptionToServerProcedureFix
 
     private String getAtClientKeyword(IXtextBslModuleFixModel model)
     {
-        return model.getScriptVariant() == ScriptVariant.RUSSIAN ? Symbols.AT_CLIENT_INTNL : Symbols.AT_CLIENT_RUS;
+        return model.getScriptVariant() == ScriptVariant.RUSSIAN ? Symbols.AT_CLIENT_RUS : Symbols.AT_CLIENT_INTNL;
     }
 }

--- a/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/NotifyDescriptionToServerProcedureFix.java
+++ b/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/NotifyDescriptionToServerProcedureFix.java
@@ -50,7 +50,7 @@ public class NotifyDescriptionToServerProcedureFix
     {
         EObject element = model.getElement();
         String stringValue = NodeModelUtils.getNode(element).getText();
-        String methodName = QuickFixMethodsHelper.getMethodName(stringValue.replace("\"", "")); //$NON-NLS-1$//$NON-NLS-2$
+        String methodName = QuickFixMethodsHelper.getMethodName(stringValue.replace("\"", "").trim()); //$NON-NLS-1$//$NON-NLS-2$
 
         QuickFixMethodsHelper.createMethod((IXtextInteractiveBslModuleFixModel)model, methodName, false, true,
             getAtClientKeyword(model, element));

--- a/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/NotifyDescriptionToServerProcedureFix.java
+++ b/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/NotifyDescriptionToServerProcedureFix.java
@@ -18,6 +18,7 @@ import org.eclipse.text.edits.TextEdit;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 import org.eclipse.xtext.resource.XtextResource;
 
+import com._1c.g5.v8.dt.bsl.common.Symbols;
 import com._1c.g5.v8.dt.metadata.mdclass.ScriptVariant;
 import com.e1c.g5.v8.dt.bsl.check.qfix.IXtextBslModuleFixModel;
 import com.e1c.g5.v8.dt.bsl.check.qfix.IXtextInteractiveBslModuleFixModel;
@@ -33,9 +34,6 @@ import com.e1c.g5.v8.dt.check.qfix.components.QuickFix;
 public class NotifyDescriptionToServerProcedureFix
     extends SingleVariantXtextBslModuleFix
 {
-    private static final String AT_CLIENT_KEYWORD = "AtClient"; //$NON-NLS-1$
-    private static final String AT_CLIENT_KEYWORD_RU = "НаКлиенте"; //$NON-NLS-1$
-
     @Override
     protected void configureFix(FixConfigurer configurer)
     {
@@ -59,7 +57,6 @@ public class NotifyDescriptionToServerProcedureFix
 
     private String getAtClientKeyword(IXtextBslModuleFixModel model)
     {
-        boolean isRussian = model.getScriptVariant() == ScriptVariant.RUSSIAN;
-        return isRussian ? AT_CLIENT_KEYWORD_RU : AT_CLIENT_KEYWORD;
+        return model.getScriptVariant() == ScriptVariant.RUSSIAN ? Symbols.AT_CLIENT_INTNL : Symbols.AT_CLIENT_RUS;
     }
 }

--- a/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/NotifyDescriptionToServerProcedureFix.java
+++ b/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/NotifyDescriptionToServerProcedureFix.java
@@ -15,10 +15,13 @@ package com.e1c.v8codestyle.bsl.ui.qfix;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.text.edits.TextEdit;
+import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 import org.eclipse.xtext.resource.XtextResource;
 
 import com._1c.g5.v8.dt.bsl.common.Symbols;
+import com._1c.g5.v8.dt.bsl.model.Module;
+import com._1c.g5.v8.dt.bsl.model.ModuleType;
 import com._1c.g5.v8.dt.metadata.mdclass.ScriptVariant;
 import com.e1c.g5.v8.dt.bsl.check.qfix.IXtextBslModuleFixModel;
 import com.e1c.g5.v8.dt.bsl.check.qfix.IXtextInteractiveBslModuleFixModel;
@@ -50,13 +53,20 @@ public class NotifyDescriptionToServerProcedureFix
         String methodName = QuickFixMethodsHelper.getMethodName(stringValue.replace("\"", "")); //$NON-NLS-1$//$NON-NLS-2$
 
         QuickFixMethodsHelper.createMethod((IXtextInteractiveBslModuleFixModel)model, methodName, false, true,
-            getAtClientKeyword(model));
+            getAtClientKeyword(model, element));
 
         return null;
     }
 
-    private String getAtClientKeyword(IXtextBslModuleFixModel model)
+    private String getAtClientKeyword(IXtextBslModuleFixModel model, EObject element)
     {
-        return model.getScriptVariant() == ScriptVariant.RUSSIAN ? Symbols.AT_CLIENT_RUS : Symbols.AT_CLIENT_INTNL;
+        Module module = EcoreUtil2.getContainerOfType(element, Module.class);
+        ModuleType type = module.getModuleType();
+
+        if (type == ModuleType.FORM_MODULE || type == ModuleType.COMMAND_MODULE)
+        {
+            return model.getScriptVariant() == ScriptVariant.RUSSIAN ? Symbols.AT_CLIENT_RUS : Symbols.AT_CLIENT_INTNL;
+        }
+        return null;
     }
 }

--- a/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/QuickFixMethodsHelper.java
+++ b/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/QuickFixMethodsHelper.java
@@ -57,10 +57,10 @@ public final class QuickFixMethodsHelper
      * Creates method and writes it to module
      *
      * @param model the xtext BSL quick fix model, cannot be {@code null}
-     * @param methodName the name of the method with (), example = "myFunctionName()" {@code null}
+     * @param methodName the name of the method with (), example = "myFunctionName()", cannot be {@code null}
      * @param isFunc indicates whether the method is function or procedure
      * @param isExport indicates method Export or not
-     * @param directiveName the name of directive, example = "OnClient"
+     * @param directiveName the name of directive, example = "OnClient", can be {@code null}
      * @throws BadLocationException
      */
     static void createMethod(IXtextInteractiveBslModuleFixModel model, String methodName, boolean isFunc,

--- a/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/QuickFixMethodsHelper.java
+++ b/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/QuickFixMethodsHelper.java
@@ -57,7 +57,7 @@ public final class QuickFixMethodsHelper
      * Creates method and writes it to module
      *
      * @param model the xtext BSL quick fix model, cannot be {@code null}
-     * @param methodName the name of the method with (), example = "myFunctionName()"
+     * @param methodName the name of the method with (), example = "myFunctionName()" {@code null}
      * @param isFunc indicates whether the method is function or procedure
      * @param isExport indicates method Export or not
      * @param directiveName the name of directive, example = "OnClient"

--- a/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/QuickFixMethodsHelper.java
+++ b/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/QuickFixMethodsHelper.java
@@ -39,9 +39,6 @@ import com.google.common.base.Strings;
  */
 public final class QuickFixMethodsHelper
 {
-    private static final String EXPORT_KEYWORD = "Export"; //$NON-NLS-1$
-    private static final String EXPORT_KEYWORD_RU = "Экспорт"; //$NON-NLS-1$
-
     /**
      * Creates method and writes it to module
      *
@@ -249,8 +246,8 @@ public final class QuickFixMethodsHelper
 
     private static String getExportKeyword(IXtextBslModuleFixModel model)
     {
-        boolean isRussian = model.getScriptVariant() == ScriptVariant.RUSSIAN;
-        return isRussian ? EXPORT_KEYWORD_RU : EXPORT_KEYWORD;
+        return BslProposalProvider.getExportLiteralName(model.getBslGrammar(),
+            model.getScriptVariant() == ScriptVariant.RUSSIAN);
     }
 
     private static int getModelNameLength(IXtextInteractiveBslModuleFixModel model)

--- a/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/QuickFixMethodsHelper.java
+++ b/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/QuickFixMethodsHelper.java
@@ -39,6 +39,9 @@ import com.google.common.base.Strings;
  */
 public final class QuickFixMethodsHelper
 {
+    private static final String EXPORT_KEYWORD = "Export"; //$NON-NLS-1$
+    private static final String EXPORT_KEYWORD_RU = "Экспорт"; //$NON-NLS-1$
+
     /**
      * Creates method and writes it to module
      *
@@ -49,9 +52,24 @@ public final class QuickFixMethodsHelper
     static void createMethod(IXtextInteractiveBslModuleFixModel model, boolean isFunc) throws BadLocationException
     {
         EObject element = model.getElement();
-
         String methodName = getMethodName(((StaticFeatureAccess)element).getName());
-        String directiveName = ""; //$NON-NLS-1$
+        createMethod(model, methodName, isFunc, false, ""); //$NON-NLS-1$
+    }
+
+    /**
+     * Creates method and writes it to module
+     *
+     * @param model the xtext BSL quick fix model, cannot be {@code null}
+     * @param methodName the name of the method with (), example = "myFunctionName()"
+     * @param isFunc indicates whether the method is function or procedure
+     * @param isExport indicates method Export or not
+     * @param directiveName the name of directive, example = "OnClient"
+     * @throws BadLocationException
+     */
+    static void createMethod(IXtextInteractiveBslModuleFixModel model, String methodName, boolean isFunc,
+        boolean isExport, String directiveName) throws BadLocationException
+    {
+        EObject element = model.getElement();
 
         //up to Method class
         Method method = EcoreUtil2.getContainerOfType(element, Method.class);
@@ -68,7 +86,7 @@ public final class QuickFixMethodsHelper
             if (indent.isPresent())
             {
                 String func = createMethod(model, indent.get(), directiveName, methodName, methodKeywordType,
-                    methodEndKeywordType);
+                    methodEndKeywordType, isExport);
 
                 // Write method to module
                 IXtextDocument document = (IXtextDocument)model.getDocument();
@@ -116,7 +134,7 @@ public final class QuickFixMethodsHelper
         return BslProposalProvider.getTypeEndMethodName(model.getBslGrammar(), isFunc, isRussion);
     }
 
-    private static String getMethodName(String name)
+    static String getMethodName(String name)
     {
         StringBuilder builder = new StringBuilder();
 
@@ -127,7 +145,7 @@ public final class QuickFixMethodsHelper
     }
 
     private static String createMethod(IXtextInteractiveBslModuleFixModel model, String indent, String directive,
-        String methodName, String methodKeyword, String methodEndKeyword)
+        String methodName, String methodKeyword, String methodEndKeyword, boolean isExport)
     {
         String lineSeparator = model.getLineSeparator();
         String commentContent = Strings.repeat(lineSeparator, 2);
@@ -143,7 +161,11 @@ public final class QuickFixMethodsHelper
             builder.append(indent).append('&').append(directive).append(lineSeparator);
         }
         builder.append(indent).append(methodKeyword).append(' ');
-        builder.append(methodName);
+        builder.append(methodName).append(' ');
+        if (isExport)
+        {
+            builder.append(getExportKeyword(model));
+        }
         builder.append(lineSeparator).append(todoComment).append(lineSeparator);
         builder.append(indent).append(methodEndKeyword);
         return builder.toString();
@@ -165,7 +187,7 @@ public final class QuickFixMethodsHelper
         }
         int posUse = model.getIssue().getOffset();
 
-        int nameLen = ((StaticFeatureAccess)model.getElement()).getName().length();
+        int nameLen = getModelNameLength(model);
         createLinkedModeModel(model, posDec, posUse, nameLen, groupParams);
     }
 
@@ -223,6 +245,22 @@ public final class QuickFixMethodsHelper
         {
             model.selectAndRevealForLinkedModeModel(posUse, length);
         }
+    }
+
+    private static String getExportKeyword(IXtextBslModuleFixModel model)
+    {
+        boolean isRussian = model.getScriptVariant() == ScriptVariant.RUSSIAN;
+        return isRussian ? EXPORT_KEYWORD_RU : EXPORT_KEYWORD;
+    }
+
+    private static int getModelNameLength(IXtextInteractiveBslModuleFixModel model)
+    {
+        EObject element = model.getElement();
+        if (element instanceof StaticFeatureAccess staticFeatureAccessElement)
+        {
+            return staticFeatureAccessElement.getName().length();
+        }
+        return NodeModelUtils.getNode(element).getText().length();
     }
 
     private QuickFixMethodsHelper()

--- a/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/messages.properties
+++ b/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/messages.properties
@@ -46,3 +46,4 @@ UndefinedMethodFix_proc_desc=Create a new procedure in the module
 UndefinedVariableFix_title=Create variable
 UndefinedVariableFix_desc=Create a missing variable in the method or module.\nSave changes in the editor after quick fix is applied.
 NotifyDescriptionToServerProcedureFix_Description=Create the missing procedure for NotifyDescription
+NotifyDescriptionToServerProcedureFix_Details=Create a new server procedure to handle the NotifyDescription callback

--- a/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/messages.properties
+++ b/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/messages.properties
@@ -45,3 +45,4 @@ UndefinedMethodFix_proc_title=Create procedure
 UndefinedMethodFix_proc_desc=Create a new procedure in the module
 UndefinedVariableFix_title=Create variable
 UndefinedVariableFix_desc=Create a missing variable in the method or module.\nSave changes in the editor after quick fix is applied.
+NotifyDescriptionToServerProcedureFix_Description=Create the missing procedure for NotifyDescription

--- a/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/messages_ru.properties
+++ b/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/messages_ru.properties
@@ -74,3 +74,5 @@ UndefinedVariableFix_desc = Создать пропущенную перемен
 UndefinedVariableFix_title = Создать переменную
 
 NotifyDescriptionToServerProcedureFix_Description= Создать отсутствующую процедуру для ОписаниеОповещения
+
+NotifyDescriptionToServerProcedureFix_Details=Создать новую серверную процедуру для обработки обратного вызова ОписаниеОповещения

--- a/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/messages_ru.properties
+++ b/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/messages_ru.properties
@@ -73,6 +73,6 @@ UndefinedVariableFix_desc = Создать пропущенную перемен
 
 UndefinedVariableFix_title = Создать переменную
 
-NotifyDescriptionToServerProcedureFix_Description= Создать отсутствующую процедуру для ОписаниеОповещения
+NotifyDescriptionToServerProcedureFix_Description = Создать отсутствующую процедуру для ОписаниеОповещения
 
 NotifyDescriptionToServerProcedureFix_Details=Создать новую серверную процедуру для обработки обратного вызова ОписаниеОповещения

--- a/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/messages_ru.properties
+++ b/bundles/com.e1c.v8codestyle.bsl.ui/src/com/e1c/v8codestyle/bsl/ui/qfix/messages_ru.properties
@@ -72,3 +72,5 @@ UndefinedMethodFix_proc_title = Создать процедуру
 UndefinedVariableFix_desc = Создать пропущенную переменную на уровне метода или модуля.\nПосле применения исправления сохраните изменения в редакторе.
 
 UndefinedVariableFix_title = Создать переменную
+
+NotifyDescriptionToServerProcedureFix_Description= Создать отсутствующую процедуру для ОписаниеОповещения

--- a/bundles/com.e1c.v8codestyle.bsl/src/com/e1c/v8codestyle/bsl/check/NotifyDescriptionToServerProcedureCheck.java
+++ b/bundles/com.e1c.v8codestyle.bsl/src/com/e1c/v8codestyle/bsl/check/NotifyDescriptionToServerProcedureCheck.java
@@ -67,7 +67,7 @@ import com.google.inject.Inject;
  * @author Victor Golubev
  */
 public class NotifyDescriptionToServerProcedureCheck
-    extends BasicCheck
+    extends BasicCheck<Object>
 {
     private static final String CHECK_ID = "notify-description-to-server-procedure"; //$NON-NLS-1$
 
@@ -231,7 +231,7 @@ public class NotifyDescriptionToServerProcedureCheck
                                 .map(Environmental.class::cast)
                                 .toList();
                         }
-                        else if (entry.getFeature() instanceof ImplicitVariable implicitVariable)
+                        else if (entry.getFeature() instanceof ImplicitVariable)
                         {
                             List<TypeItem> types =
                                 typesComputer.computeTypes(featureAccess, environmental.environments());

--- a/tests/com.e1c.v8codestyle.bsl.itests/resources/fix-notify-description-to-server-procedure.bsl
+++ b/tests/com.e1c.v8codestyle.bsl.itests/resources/fix-notify-description-to-server-procedure.bsl
@@ -1,0 +1,6 @@
+&AtClient
+Procedure Test()
+
+    MyVar1 = New NotifyDescription("Aaaaa", ThisObject);
+    
+EndProcedure

--- a/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/fix/itests/AbstractQuickFixTest.java
+++ b/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/fix/itests/AbstractQuickFixTest.java
@@ -15,11 +15,9 @@ package com.e1c.v8codestyle.bsl.fix.itests;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 
 import com._1c.g5.v8.dt.validation.marker.Marker;
@@ -51,10 +49,10 @@ public abstract class AbstractQuickFixTest
     /**
      * This method perform the fix and modifying the project code
      *
-     * @throws CoreException
-     * @throws IOException
+     * @param marker the found marker in the project {@code null}
+     * @param fixDescription {@code null}
      */
-    protected void performFix(Marker marker, String fixDescription) throws CoreException, IOException
+    protected void performFix(Marker marker, String fixDescription)
     {
         FixProcessHandle handle = fixManager.prepareFix(marker, getProject());
 
@@ -81,9 +79,8 @@ public abstract class AbstractQuickFixTest
 
     /**
      * The method performs a validity check for the current project
-     * @throws Exception
      */
-    protected void assertMarkerGone() throws Exception
+    protected void assertMarkerGone()
     {
         waitForDD(getProject());
         List<Marker> markers = getModuleMarkers();

--- a/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/fix/itests/AbstractQuickFixTest.java
+++ b/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/fix/itests/AbstractQuickFixTest.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (C) 2026, 1C-Soft LLC and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     1C-Soft LLC - initial API and implementation
+ *******************************************************************************/
+package com.e1c.v8codestyle.bsl.fix.itests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+
+import com._1c.g5.v8.dt.validation.marker.Marker;
+import com._1c.g5.wiring.ServiceAccess;
+import com.e1c.g5.v8.dt.check.ICheck;
+import com.e1c.g5.v8.dt.check.qfix.FixProcessHandle;
+import com.e1c.g5.v8.dt.check.qfix.FixVariantDescriptor;
+import com.e1c.g5.v8.dt.check.qfix.IFixManager;
+import com.e1c.v8codestyle.bsl.check.itests.AbstractSingleModuleTestBase;
+
+/**
+ *  QuickFix helper for tests
+ *
+ *  @author Artem Samohvalov
+ */
+public abstract class AbstractQuickFixTest
+    extends AbstractSingleModuleTestBase
+{
+    private IFixManager fixManager = ServiceAccess.get(IFixManager.class);
+
+    /**
+     * @param checkClass
+     */
+    protected AbstractQuickFixTest(Class<? extends ICheck> checkClass)
+    {
+        super(checkClass);
+    }
+
+    /**
+     * This method perform the fix and modifying the project code
+     *
+     * @throws CoreException
+     * @throws IOException
+     */
+    public void performFix(Marker marker, String fixDescription) throws CoreException, IOException
+    {
+        FixProcessHandle handle = fixManager.prepareFix(marker, getProject());
+
+        FixVariantDescriptor variantDescr = null;
+
+        Collection<FixVariantDescriptor> variants = fixManager.getApplicableFixVariants(handle);
+        for (FixVariantDescriptor variant : variants)
+        {
+            if (variant.getDescription().equals(fixDescription))
+            {
+                variantDescr = variant;
+            }
+        }
+        assertNotNull(variantDescr);
+
+        fixManager.selectFixVariant(variantDescr, handle);
+        fixManager.executeFix(handle, new NullProgressMonitor());
+        fixManager.finishFix(handle);
+
+        updateProject();
+    }
+
+    /**
+     * The method performs a validity check for the current project
+     * @throws Exception
+     */
+    public void assertMarkerGone() throws Exception
+    {
+        waitForDD(getProject());
+        List<Marker> markers = getModuleMarkers();
+        assertEquals(0, markers.size());
+    }
+
+    private void updateProject() throws CoreException, IOException
+    {
+        IFile file = getProject().getWorkspaceProject().getFile(getModuleFileName());
+        try (InputStream in = file.getContents())
+        {
+            file.setContents(in, true, true, new NullProgressMonitor());
+        }
+
+        waitForDD(getProject());
+    }
+}

--- a/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/fix/itests/AbstractQuickFixTest.java
+++ b/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/fix/itests/AbstractQuickFixTest.java
@@ -16,11 +16,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Collection;
 import java.util.List;
 
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 
@@ -76,7 +74,7 @@ public abstract class AbstractQuickFixTest
         fixManager.executeFix(handle, new NullProgressMonitor());
         fixManager.finishFix(handle);
 
-        updateProject();
+        waitForDD(getProject());
     }
 
     /**
@@ -88,16 +86,5 @@ public abstract class AbstractQuickFixTest
         waitForDD(getProject());
         List<Marker> markers = getModuleMarkers();
         assertEquals(0, markers.size());
-    }
-
-    private void updateProject() throws CoreException, IOException
-    {
-        IFile file = getProject().getWorkspaceProject().getFile(getModuleFileName());
-        try (InputStream in = file.getContents())
-        {
-            file.setContents(in, true, true, new NullProgressMonitor());
-        }
-
-        waitForDD(getProject());
     }
 }

--- a/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/fix/itests/AbstractQuickFixTest.java
+++ b/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/fix/itests/AbstractQuickFixTest.java
@@ -89,14 +89,4 @@ public abstract class AbstractQuickFixTest
         List<Marker> markers = getModuleMarkers();
         assertEquals(0, markers.size());
     }
-
-    /**
-     * How to get real language?
-     *
-     * @return boolean
-     */
-    protected boolean isRussianLocalization()
-    {
-        return true;
-    }
 }

--- a/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/fix/itests/AbstractQuickFixTest.java
+++ b/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/fix/itests/AbstractQuickFixTest.java
@@ -54,7 +54,7 @@ public abstract class AbstractQuickFixTest
      * @throws CoreException
      * @throws IOException
      */
-    public void performFix(Marker marker, String fixDescription) throws CoreException, IOException
+    protected void performFix(Marker marker, String fixDescription) throws CoreException, IOException
     {
         FixProcessHandle handle = fixManager.prepareFix(marker, getProject());
 
@@ -66,8 +66,10 @@ public abstract class AbstractQuickFixTest
             if (variant.getDescription().equals(fixDescription))
             {
                 variantDescr = variant;
+                break;
             }
         }
+
         assertNotNull(variantDescr);
 
         fixManager.selectFixVariant(variantDescr, handle);
@@ -81,10 +83,20 @@ public abstract class AbstractQuickFixTest
      * The method performs a validity check for the current project
      * @throws Exception
      */
-    public void assertMarkerGone() throws Exception
+    protected void assertMarkerGone() throws Exception
     {
         waitForDD(getProject());
         List<Marker> markers = getModuleMarkers();
         assertEquals(0, markers.size());
+    }
+
+    /**
+     * How to get real language?
+     *
+     * @return boolean
+     */
+    protected boolean isRussianLocalization()
+    {
+        return true;
     }
 }

--- a/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/fix/itests/AbstractQuickFixTest.java
+++ b/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/fix/itests/AbstractQuickFixTest.java
@@ -39,8 +39,9 @@ public abstract class AbstractQuickFixTest
     private IFixManager fixManager = ServiceAccess.get(IFixManager.class);
 
     /**
-     * @param checkClass
+     * @param checkClass, cannot be {@code null}
      */
+    @SuppressWarnings("rawtypes")
     protected AbstractQuickFixTest(Class<? extends ICheck> checkClass)
     {
         super(checkClass);
@@ -49,8 +50,8 @@ public abstract class AbstractQuickFixTest
     /**
      * This method perform the fix and modifying the project code
      *
-     * @param marker the found marker in the project {@code null}
-     * @param fixDescription {@code null}
+     * @param marker the found marker in the project, cannot be {@code null}
+     * @param fixDescription, cannot be {@code null}
      */
     protected void performFix(Marker marker, String fixDescription)
     {

--- a/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/fix/itests/Messages.java
+++ b/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/fix/itests/Messages.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (C) 2026, 1C-Soft LLC and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     1C-Soft LLC - initial API and implementation
+ *******************************************************************************/
+package com.e1c.v8codestyle.bsl.fix.itests;
+
+import org.eclipse.osgi.util.NLS;
+
+/**
+ * NLS messages
+ *
+ * @author Artem Samohvalov
+ */
+final class Messages
+    extends NLS
+{
+    private static final String BUNDLE_NAME = Messages.class.getPackageName() + ".messages";
+
+    public static String NotifyDescriptionToServerProcedureFix_Description;
+
+    static
+    {
+        // initialize resource bundle
+        NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+    }
+
+    private Messages()
+    {
+        // N/A
+    }
+}

--- a/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/fix/itests/NotifyDescriptionToServerProcedureFixTest.java
+++ b/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/fix/itests/NotifyDescriptionToServerProcedureFixTest.java
@@ -13,11 +13,13 @@
 package com.e1c.v8codestyle.bsl.fix.itests;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
 import org.junit.Test;
 
+import com._1c.g5.v8.dt.bsl.model.Module;
 import com._1c.g5.v8.dt.validation.marker.Marker;
 import com.e1c.v8codestyle.bsl.check.NotifyDescriptionToServerProcedureCheck;
 
@@ -29,6 +31,9 @@ import com.e1c.v8codestyle.bsl.check.NotifyDescriptionToServerProcedureCheck;
 public class NotifyDescriptionToServerProcedureFixTest
     extends AbstractQuickFixTest
 {
+    private static final String FIX_DESCRIPTION = "Create the missing procedure for NotifyDescription";
+    private static final String FIX_DESCRIPTION_RU = "Создать отсутствующую процедуру для ОписаниеОповещения";
+
     public NotifyDescriptionToServerProcedureFixTest()
     {
         super(NotifyDescriptionToServerProcedureCheck.class);
@@ -43,8 +48,16 @@ public class NotifyDescriptionToServerProcedureFixTest
         assertEquals(1, markers.size());
         Marker marker = markers.get(0);
 
-        performFix(marker, "Создать отсутствующую процедуру для ОписаниеОповещения");
+        performFix(marker, isRussianLocalization() ? FIX_DESCRIPTION_RU : FIX_DESCRIPTION);
         assertMarkerGone();
+
+        assertHasMethod();
     }
 
+    private void assertHasMethod()
+    {
+        Module module = getModule();
+        // find created method in module
+        assertTrue(module.allMethods().stream().anyMatch(m -> m.getName().equals("Aaaaa")));
+    }
 }

--- a/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/fix/itests/NotifyDescriptionToServerProcedureFixTest.java
+++ b/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/fix/itests/NotifyDescriptionToServerProcedureFixTest.java
@@ -31,9 +31,6 @@ import com.e1c.v8codestyle.bsl.check.NotifyDescriptionToServerProcedureCheck;
 public class NotifyDescriptionToServerProcedureFixTest
     extends AbstractQuickFixTest
 {
-    private static final String FIX_DESCRIPTION = "Create the missing procedure for NotifyDescription";
-    private static final String FIX_DESCRIPTION_RU = "Создать отсутствующую процедуру для ОписаниеОповещения";
-
     public NotifyDescriptionToServerProcedureFixTest()
     {
         super(NotifyDescriptionToServerProcedureCheck.class);
@@ -48,7 +45,7 @@ public class NotifyDescriptionToServerProcedureFixTest
         assertEquals(1, markers.size());
         Marker marker = markers.get(0);
 
-        performFix(marker, isRussianLocalization() ? FIX_DESCRIPTION_RU : FIX_DESCRIPTION);
+        performFix(marker, Messages.NotifyDescriptionToServerProcedureFix_Description);
         assertMarkerGone();
 
         assertHasMethod();
@@ -58,6 +55,6 @@ public class NotifyDescriptionToServerProcedureFixTest
     {
         Module module = getModule();
         // find created method in module
-        assertTrue(module.allMethods().stream().anyMatch(m -> m.getName().equals("Aaaaa")));
+        assertTrue(module.allMethods().stream().anyMatch(m -> "Aaaaa".equals(m.getName())));
     }
 }

--- a/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/fix/itests/NotifyDescriptionToServerProcedureFixTest.java
+++ b/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/fix/itests/NotifyDescriptionToServerProcedureFixTest.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (C) 2026, 1C-Soft LLC and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     1C-Soft LLC - initial API and implementation
+ *******************************************************************************/
+package com.e1c.v8codestyle.bsl.fix.itests;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com._1c.g5.v8.dt.validation.marker.Marker;
+import com.e1c.v8codestyle.bsl.check.NotifyDescriptionToServerProcedureCheck;
+
+/**
+ *  Tests for NotifyDescriptionToServerProcedureFix fix.
+ *
+ *  @author Artem Samohvalov
+ */
+public class NotifyDescriptionToServerProcedureFixTest
+    extends AbstractQuickFixTest
+{
+    public NotifyDescriptionToServerProcedureFixTest()
+    {
+        super(NotifyDescriptionToServerProcedureCheck.class);
+    }
+
+    @Test
+    public void testApplyFix() throws Exception
+    {
+        updateModule(FOLDER_RESOURCE + "fix-notify-description-to-server-procedure.bsl");
+
+        List<Marker> markers = getModuleMarkers();
+        assertEquals(1, markers.size());
+        Marker marker = markers.get(0);
+
+        performFix(marker, "Создать отсутствующую процедуру для ОписаниеОповещения");
+        assertMarkerGone();
+    }
+
+}

--- a/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/fix/itests/messages.properties
+++ b/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/fix/itests/messages.properties
@@ -1,0 +1,1 @@
+NotifyDescriptionToServerProcedureFix_Description=Create the missing procedure for NotifyDescription

--- a/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/fix/itests/messages_ru.properties
+++ b/tests/com.e1c.v8codestyle.bsl.itests/src/com/e1c/v8codestyle/bsl/fix/itests/messages_ru.properties
@@ -1,0 +1,1 @@
+NotifyDescriptionToServerProcedureFix_Description = Создать отсутствующую процедуру для ОписаниеОповещения


### PR DESCRIPTION
## Что сделано

- Добавлен QuickFix - NotifyDescriptionToServerProcedureFix для создания процедуры в обработчике события
- Изменен класс QuickFixMethodsHelper, реализована функциональность создания экспортируемых методов и методов с директивой компиляции

## Чек-лист

<!-- 
Перед отправкой вашего PR на аудит пройдите по чек-листу, выполните задачи, отметьте каждый пункт (если применимо).
Если что-то не понятно - лучше уточните в чате.
-->

Общее:
- [ ] ветка PR обновлена из `master` и нет конфликтов
- [ ] Тесты-кейсы, JUnit тесты правильного и неправильного состояния
- [ ] Измененные Вами исходники отформатированы в соответствии [с конвенцией](https://github.com/1C-Company/v8-code-style/blob/master/docs/contributing/code_style.md)
- [ ] Авто-аудит (SonarQube и CheckStyle) пройден, покрытие кода хорошее, ошибок нет, плохой код устранен
- [ ] Добавлена запись в [ИСТОРИЮ ИЗМЕНЕНИЯ](https://github.com/1C-Company/v8-code-style/blob/master/CHANGELOG.md), включаемая в пользовательскую документацию плагина

Если применимо:
- [ ] Пользовательская документация на доп.инструменты написана (на русском)
- [ ] Описание проверок - на двух языках

## Закрываемые задачи

<!-- 
Укажите номер закрываемой задачи (обязательно!)
Например: Closes #123
-->

Closes #[1170](https://github.com/1C-Company/v8-code-style/issues/1170)

<!-- 
С реквестом можно работать долго в статусе Draft (черновик).
По окончании работ, выполнению чек-листа - добавьте комментарий для начала аудита:
@1C-Company @marmyshev прошу сделать аудит
-->
